### PR TITLE
feat(skills): add pr-review skill + /v:pr-review command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers-v",
       "description": "Compound V for Superpowers: triple parallel pre-flight (code archaeology + domain-expert + Context7 library validator), disjoint partitioning, manifest-driven multi-backend dispatch (Claude + Codex + Antigravity + Cursor), git-diff scope enforcement, crash-resumable runs, adaptive tier-based routing, epic mode, V-memory local-first semantic+lexical recall over docs/superpowers (opt-in pure-python embeddings + a deterministic recall→action bridge), and batched parallel dispatch (Opus default, narrow Sonnet exception)",
-      "version": "2.5.5",
+      "version": "2.6.0",
       "source": "./",
       "author": {
         "name": "Oleg",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-v",
   "description": "Compound V for Superpowers: triple parallel pre-flight (code archaeology + domain-expert advisor + library/doc validator via Context7), disjoint file partitioning, manifest-driven multi-backend dispatch (Claude + headless Codex + Antigravity + Cursor workers), git-diff scope enforcement, crash-resumable runs, adaptive tier-based routing, epic mode for multi-feature builds, V-memory local-first semantic+lexical recall over docs/superpowers (opt-in pure-python embeddings + a deterministic recall\u2192action bridge), and batched parallel dispatch (Opus default, Sonnet for narrow junior-task carve-out), plus /v:onboard — a project-onboarding command that builds a citation-verified knowledge base + AGENTS.md/CLAUDE.md bridge behind a human gate. Auto-intercepts brainstorming \u2192 writing-plans \u2192 execution transitions.",
-  "version": "2.5.5",
+  "version": "2.6.0",
   "author": {
     "name": "Oleg",
     "email": "copeus@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **superpowers-v (Compound V)** are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses semantic versioning.
 
+## [2.6.0] — 2026-07-06
+
+### Added — `pr-review` skill + `/v:pr-review` command
+
+- **`pr-review` skill** — a two-axis, stack-agnostic **deep code-review** skill for a pull/merge request or a local diff. It first builds shared understanding of the change's intent, then hunts bugs and edge cases along **two deliberately separate axes** run as context-isolated sub-agents so neither pollutes the other: **Standards** (does the code follow *this repo's* documented conventions, discovered in a Phase-0 sweep?) ⊥ **Spec** (does it faithfully implement the originating spec/issue/PRD?). Findings are reported **side by side, never merged across axes**; genuine author-intent unknowns are promoted to Open Questions; every finding carries a **verdict + confidence**. **Review-only — it never edits, commits, pushes, or merges code.** Ships `SKILL.md` + four `references/` (exploration checklist, review domains, findings format, comment-posting).
+- **`/v:pr-review` command** — a thin entry point in the `/v:*` family that runs the skill. Argument = PR/MR URL or number; empty = current branch vs. its base. Auto-detects the host: GitHub (`gh`), GitLab (`glab`), or a hostless local diff.
+- **Self-contained** — no new runtime deps, hooks, or scripts; frontmatter within the linter's limits and all intra-plugin `.md` cross-refs resolve.
+
 ## [2.5.5] — 2026-07-05
 
 ### Performance

--- a/commands/v-pr-review.md
+++ b/commands/v-pr-review.md
@@ -1,0 +1,18 @@
+---
+description: Deep, two-axis, stack-agnostic code review of a pull/merge request or a local diff — review-only, never edits code. Runs the pr-review skill. Works on GitHub (gh), GitLab (glab), or a hostless local branch. Argument = PR/MR URL or number; empty = current branch vs base.
+---
+
+You are running a **deep PR/MR code review** on `{{args}}` — a pull/merge request URL or number, or, if empty, the current branch against its base.
+
+Invoke the [`pr-review`](../skills/pr-review/SKILL.md) skill and follow it exactly. The skill is **review-only**: it never edits, commits, pushes, or merges code.
+
+## Steps
+
+1. **Resolve the target.** Use `{{args}}` as the PR/MR URL or number. If empty, review the current branch against its base. The skill auto-detects the host — GitHub (`gh`), GitLab (`glab`), or a hostless local diff.
+2. **Run the pr-review skill** end-to-end: build shared understanding of the change's intent, then hunt bugs and edge cases along the two deliberately separate axes — **Standards** (does the code follow *this repo's* documented conventions?) ⊥ **Spec** (does it faithfully implement the originating spec/issue?) — run as context-isolated sub-agents. Promote real unknowns to Open Questions for the author. Every finding gets a verdict + confidence.
+3. **Hand back** the triaged findings table. Never modify the reviewed code — if the user asks for a fix mid-review, stop and confirm they want to leave the review first.
+
+## Notes
+
+- Review-only — no edits, commits, pushes, or merges (skill Prime Directive 1).
+- Full behavior — exploration checklist, review domains, findings format, and comment-posting — lives in [`skills/pr-review/SKILL.md`](../skills/pr-review/SKILL.md) and its `references/`.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-review
 description: Use when the user wants to deeply review a pull/merge request or a local diff — "review this PR", "grill the MR", "stress-test this diff", "deep-dive code review", "code review before merge", or when they name a PR/MR URL, number, or feature branch. Works on GitHub (gh), GitLab (glab), or a plain local branch with no host. Review-only — never edits code.
-argument-hint: PR/MR URL or number | empty = current branch vs base
 ---
 
 # PR Review — Two-Axis, Stack-Agnostic Deep Code Review
@@ -194,7 +193,9 @@ Assign two mandatory fields per finding:
 - **Confidence:** High (verified by grep/code reading) / Medium (plausible pattern) / Low (suspicion).
 - **Verdict:** `Fix before merge` / `Reviewer decides` / `Verify before merge` / `Nice-to-have` / `Confirmed safe`.
 
-**Auto Mode:** assign autonomously. **Otherwise:** present as `AskUserQuestion` batch(es) and let the user adjust.
+**Auto Mode** (the user opted into autonomous operation — e.g. "review it, don't ask me", or a
+non-interactive run): assign verdict + confidence autonomously, no `AskUserQuestion` batch.
+**Otherwise:** present as `AskUserQuestion` batch(es) and let the user adjust.
 
 **Exit gate:** every row has Confidence + Verdict.
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: pr-review
+description: Use when the user wants to deeply review a pull/merge request or a local diff — "review this PR", "grill the MR", "stress-test this diff", "deep-dive code review", "code review before merge", or when they name a PR/MR URL, number, or feature branch. Works on GitHub (gh), GitLab (glab), or a plain local branch with no host. Review-only — never edits code.
+argument-hint: PR/MR URL or number | empty = current branch vs base
+---
+
+# PR Review — Two-Axis, Stack-Agnostic Deep Code Review
+
+## Philosophy
+
+The purpose of reviewing a change is to build **shared understanding** of what the change is trying to do, then systematically hunt for the bugs and edge cases that intent reveals. Every diff carries implicit assumptions, unstated invariants, and ambiguous decisions. The review walks through them one by one.
+
+When neither the codebase nor the user can resolve a question deterministically — when it's a real unknown about author intent or non-local context — that question itself becomes a review comment for the author to answer. The goal is **zero unexamined assumptions** before the review is finalized.
+
+### The two review axes (Standards ⊥ Spec)
+
+The diff is checked along **two deliberately separate axes** by parallel, context-isolated sub-agents (Phase 3.5):
+
+- **Standards** — does the code conform to *this repo's* documented conventions (discovered in Phase 0)?
+- **Spec** — does the code faithfully implement the originating spec / issue / story / PRD?
+
+A change can pass one axis and fail the other:
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+The two axes run as **separate sub-agents** so neither pollutes the other's context, and their findings are reported **side by side, never merged or reranked across axes** — separation stops one axis from masking the other.
+
+## Prime Directives
+
+1. **Review only — never modify code.** No edits, fixes, commits, pushes, or merges. If the user asks for a fix mid-review, stop and confirm they want to leave the review before touching code.
+2. **Exhaust the codebase before asking.** Every question to the user (or the author) must include an `Already checked:` line citing what you grepped/read and why it didn't answer it. If you can't write that line, you haven't explored enough. See [references/exploration-checklist.md](references/exploration-checklist.md).
+3. **Use AskUserQuestion for every judgment question.** Never plain-text a question. Lead with your recommendation (first option, `(Recommended)`). Batch up to 4 same-domain questions per call.
+4. **Don't surface what the code already answers.** Anti-pattern: asking something that 30 seconds of `grep` resolves. Reserve user questions for genuine judgment calls and author-intent for genuine non-local unknowns.
+5. **Stay concrete.** Anchor every question and finding to a specific `file:line` and a specific failure mode.
+6. **Promote real unknowns to review comments.** When neither code nor user can answer, record as an Open Question for the Author (defaults to post = `[x]`).
+7. **Verdict and confidence are mandatory.** Every finding gets both before the user sees the triage table.
+
+## Non-Goals
+
+- ❌ Editing the change's code, tests, or docs
+- ❌ Running migrations, fixing bugs, applying suggestions
+- ❌ Merging, closing, or approving the PR/MR
+- ❌ Pushing commits
+- ❌ Re-printing the findings table in chat after writing it to the file (unless asked)
+
+The only host side-effects this skill performs are **posting review comments** (Phase 7) and **updating the PR/MR title verdict icon** (Phase 8), both only on explicit user confirmation, and skipped entirely in local-branch mode.
+
+---
+
+## Inputs & VCS Auto-Detection
+
+Resolve the target and the host **once**, in Phase 0. Pick the cheapest mode that works — never require a host.
+
+| Input | Mode | How to fetch |
+|-------|------|--------------|
+| PR/MR **URL** | host from the URL domain | `github.com` → `gh`; `gitlab.*` → `glab` |
+| PR/MR **number** | host from `git remote get-url origin` | github.com → `gh`; gitlab.* → `glab` |
+| **empty / "current branch"** | **local** (no host) | `git diff <base>...HEAD`, `git log <base>..HEAD` |
+
+**Host detection:** parse `git remote get-url origin`. If it contains `github.com` and `gh` exists → GitHub. If it contains `gitlab` and `glab` exists → GitLab. If neither CLI is present, or the remote is unknown, **fall back to local mode** and tell the user posting will be unavailable.
+
+**Base branch detection:** `git symbolic-ref refs/remotes/origin/HEAD` → strip to branch name; fall back to `main`, then `master`. Confirm with the user via `AskUserQuestion` only if ambiguous.
+
+**Metadata fetch (host modes):**
+- GitHub: `gh pr view {n} --json title,body,author,baseRefName,headRefName,files,additions,deletions,headRefOid,commits` + `gh pr diff {n}`
+- GitLab: `glab mr view {n}` (or `glab api projects/:id/merge_requests/{n}`) + `glab mr diff {n}`
+
+If the input is ambiguous, ask via `AskUserQuestion`.
+
+---
+
+## Source Auto-Discovery (the stack-agnostic core)
+
+Do NOT hardcode any project's doc paths. In Phase 0, **discover** the two axes' sources by globbing well-known locations and matching to the changed areas. Record what you found (and what you didn't) in the findings file.
+
+**Standards-axis sources** (read those that exist, prefer ones relevant to the changed files):
+- Instruction files: `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `GEMINI.md` (repo root **and** nested dirs touched by the diff), `CONTRIBUTING.md`, `.cursorrules`
+- Convention docs: `docs/coding-standards/**`, `docs/**/best_practices*/**`, `docs/conventions/**`, `docs/architecture/**`, `docs/**/style*`
+- Tooling configs as ground truth: `.editorconfig`, `eslint*`, `.prettier*`, `tsconfig*`, `ruff*`, `.golangci*` — but **skip anything the linter already enforces** (don't re-flag what CI catches).
+
+**Spec-axis sources** (first match wins; if none → "no spec available"):
+- A spec/PRD matching the branch/feature: `specs/*/spec.md`, `specs/**/spec.md`, `docs/prd/**`, `docs/specs/**`, `.scratch/**` (match by branch slug or feature name).
+- A **linked issue/story** referenced in the branch name or PR/MR body. Parse common ID shapes: `#NNN`, `GH-NNN`, `sc-NNNNN`, `[A-Z]+-\d+` (Jira), GitLab `!NN`/`#NN`. Fetch via `gh issue view` / `glab issue view` when a host is available.
+- If multiple candidates, ask the user which is authoritative (`AskUserQuestion`).
+
+**Exit:** the findings file's `## What this PR does` section names the Standards sources read and the Spec source (or "no spec available").
+
+---
+
+## Two Modes: First Review vs Re-Review
+
+Decided in Phase 0 by whether **the current user already has comments on this PR/MR**:
+
+- **First review** — full phase order: context → briefing → audit → two-axis pre-pass → interrogation → verdict → triage → post.
+- **Re-review** — the change was already reviewed and the author presumably pushed responses. Skip heavy context-gathering and full interrogation; instead confirm what changed, check each prior comment for resolution, sanity-check the new commits, produce a verdict. **The re-review verdict is always presented for user confirmation — never finalized autonomously.**
+
+**Detection (Phase 0):** after fetching comments, get the current user (`gh api user --jq .login` / `glab api user --jq .username`) and match against comment authors (GitHub: `gh pr view {n} --comments` + `gh api repos/{owner}/{repo}/pulls/{n}/comments`; GitLab: `glab api projects/:id/merge_requests/{n}/notes`). Prior comments by the current user → **re-review** ([flow below](#re-review-flow)). Else → first review. Ambiguous → ask.
+
+In **local mode** there are no host comments — always first review.
+
+---
+
+## Worktree Isolation (optional, host modes)
+
+So a review never disturbs the user's working tree or another concurrent review:
+
+1. **Never `git checkout` in the session's working tree.** Materialize the PR/MR in a dedicated detached worktree.
+2. Deterministic path so concurrent sessions converge: `<repo-parent>/<repo>-reviews/pr-{n}`.
+3. Worktrees are **detached, read-only, disposable.** Never edit/build/commit inside (Prime Directive 1).
+4. Run all grep/read against the worktree with absolute paths.
+
+```bash
+MAIN_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+REVIEW_WT="$MAIN_REPO/../${REPO_NAME}-reviews/pr-{n}"
+# GitHub: git fetch origin "pull/{n}/head" ; GitLab: git fetch origin "merge-requests/{n}/head"
+git fetch origin "<pull-ref>"
+git worktree add --detach "$REVIEW_WT" FETCH_HEAD
+```
+
+- Reuse `$REVIEW_WT` if it exists; refresh to the head SHA if stale.
+- If worktree creation fails, fall back to read-only inspection: fetch the ref and read files via `git show <ref>:{path}`.
+- **Skip entirely in local mode** — the session's own worktree IS the review target.
+- The **findings file lives in the launch repo** (`./reviews/`), never inside the disposable worktree.
+- Offer `git worktree remove "$REVIEW_WT"` at the end (decline if another session may still use it).
+
+---
+
+## Phase Order (the spine — each phase has an exit gate; do not skip)
+
+### Phase 0 — Context Setup
+1. Resolve target + host + base branch (see Inputs). Fetch metadata, diff, head SHA, comments. **Determine the mode** (first vs re-review). If re-review → jump to the [Re-Review Flow](#re-review-flow).
+2. (Host modes) Materialize the PR/MR in an isolated worktree.
+3. **Auto-discover the Standards and Spec sources** (see Source Auto-Discovery).
+4. Read the changed files in full (surrounding context, not just hunks).
+5. Read existing review comments; don't re-litigate.
+
+**Exit gate:** none — proceed to Phase 1 (first review) or the Re-Review Flow.
+
+### Phase 1 — "What this PR does" Briefing (mandatory, before any interrogation)
+Plain-English, zoomed out enough to picture the change inside the whole system. Three parts:
+1. **What** — user-facing terms, one short paragraph.
+2. **Why** — the problem it solves and where it sits in the product (what depends on it, what it depends on, what stage the area is in: new feature / hardening / migration / cleanup). One–two short paragraphs.
+3. **How** — a 1–3 bullet structural sketch of the layers/files touched and how they connect. NOT a line-by-line diff summary.
+
+Write it to the findings file under `## What this PR does`. Present it; the user confirms or corrects.
+
+**Exit gate:** user confirms the briefing (or accepts corrections). Do not start Phase 2 before this.
+
+### Phase 2 — Description Audit
+Does the PR/MR body actually describe the change?
+- **Empty/boilerplate** → finding, severity Low, post=`[x]`, ask author to add a description.
+- **Stale/partial** → finding flagging the divergence.
+- **Accurate** → no finding.
+
+(In local mode with no PR yet, skip.) **Exit gate:** none.
+
+### Phase 3 — Diff Anchor Classification
+For each file in context, classify:
+- **Inline-anchorable** — file appears in the diff. Inline comments will work.
+- **Summary-only** — referenced but NOT modified. Inline comments will fail; findings go in the review body, citing `file:line` in prose.
+
+**Exit gate:** none — but every finding from Phase 4 on MUST carry its anchor class.
+
+### Phase 3.5 — Two-Axis Parallel Pre-Pass (Standards ⊥ Spec)
+Run **two context-isolated sub-agents in parallel** (two `Agent` calls, `subagent_type: general-purpose`, ONE message) to produce a baseline along each axis. This front-loads deterministic, codebase-grounded findings so Phase 4 can focus on judgment calls.
+
+Pin the inputs (gathered in Phase 0): the diff command + commit list; the discovered Standards sources; the discovered Spec source (or "no spec available"). Each sub-agent runs all grep/read against the review worktree (or local tree) with absolute paths.
+
+**Standards sub-agent prompt** (include diff command + commit list + discovered Standards source paths):
+> Report — per file/hunk — every place the diff violates a documented convention in this repo. Use the provided instruction/convention files to find the relevant rule per changed area. Cite the source file + the specific rule for each finding. Distinguish hard violations (rule clearly broken) from judgement calls (rule arguably bent). Skip anything tooling enforces (lint/format). Anchor each to `file:line`. Under 400 words. Return the report as your final message — it is data, not a human-facing summary.
+
+**Spec sub-agent prompt** (include diff command + commit list + the spec/issue path or contents):
+> Report: (a) requirements the spec asked for that are missing or only partially implemented; (b) behaviour in the diff the spec did not ask for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line / acceptance criterion for each finding. Anchor each to `file:line`. Under 400 words. Return the report as your final message — it is data, not a human-facing summary. If no spec was provided, reply exactly: "No spec available."
+
+**Aggregate** into the findings file under `## Two-Axis Pre-Pass` with two sub-headings — `### Standards` and `### Spec` — holding each report **verbatim (lightly cleaned)**. Do NOT merge, dedupe across the two, or rerank between axes. End with one summary line per axis (count + single worst issue *within that axis*). Do not pick a winner across axes.
+
+**Feeding Phase 4:** treat each pre-pass finding as a candidate. Standards findings flow into Domain 9 (Conventions); Spec findings into Domain 1 (Intent Alignment). Each candidate is confirmed (promoted with verdict/confidence/anchor in Phase 5), downgraded to no-finding, or promoted to an Open Question. The Prime-Directive-2 exploration gate still applies.
+
+**Exit gate:** both reports written under `## Two-Axis Pre-Pass` (Spec may read "No spec available").
+
+### Phase 4 — Domain Interrogation
+Work through [references/review-domains.md](references/review-domains.md), starting with **Domain 0 (Dead Code & Call-Graph Reality Check)**, then **Domain 1 (Intent Alignment)**, then by relevance. For each domain:
+1. Identify the lines/files that fall under it.
+2. **Run the [exploration checklist](references/exploration-checklist.md) per question.** Write the `Already checked:` line. If empty, keep exploring.
+3. Route: code answers it → record finding directly; genuine judgment → `AskUserQuestion` (batched ≤4, same domain); genuine author-intent unknown → Open Question.
+4. **Loop-break:** if the user answers "not sure / verify" 2+ times in one batch, STOP the batch, go re-explore, return with grounded recommendations.
+5. Append a one-line summary per domain to the findings file.
+
+**Exit gate:** every relevant domain covered; findings file updated per domain.
+
+### Phase 5 — Verdict & Confidence Pass
+Assign two mandatory fields per finding:
+- **Confidence:** High (verified by grep/code reading) / Medium (plausible pattern) / Low (suspicion).
+- **Verdict:** `Fix before merge` / `Reviewer decides` / `Verify before merge` / `Nice-to-have` / `Confirmed safe`.
+
+**Auto Mode:** assign autonomously. **Otherwise:** present as `AskUserQuestion` batch(es) and let the user adjust.
+
+**Exit gate:** every row has Confidence + Verdict.
+
+### Phase 6 — Triage With User
+Present the complete findings table ([references/findings-format.md](references/findings-format.md)). User checks `[x]` in Post?. Defaults: Open Questions → `[x]`; Confirmed-safe → `[ ]`; Low hygiene → `[ ]`; everything else → `[ ]` (opt in).
+
+**Exit gate:** user finalized Post? selections.
+
+### Phase 7 — Post Comments (explicit instruction only; host modes only)
+Do not post on Phase-6 completion — wait for "post the comments". Route per Phase-3 anchor class (inline vs summary). See [references/posting-comments.md](references/posting-comments.md) for the gh + glab recipes (head SHA, payload shapes, GitLab discussion positions, fallbacks). After posting, report which comments went out (URLs); mark posted rows `[posted]`. **Local mode: skip — the findings file is the deliverable.**
+
+### Phase 8 — Update PR/MR Title Verdict Icon (optional; host modes only)
+After the outcome is settled, prefix the title with the icon(s):
+
+| Icon | Meaning |
+|------|---------|
+| 💬 | Comment / open questions awaiting the author; no blocking issues |
+| 🔴 | Change required — at least one `Fix before merge` finding |
+| 🟢 | Approved / ready to merge — no blocking findings |
+
+Combine when mixed (common: **🟢💬**), strongest-first (🔴 before 💬; 🟢 before 💬). **Replace, don't stack** — strip existing icon(s) first. Update via `gh pr edit {n} --title "…"` / `glab mr update {n} --title "…"`. Confirm with the user first. Skip in local mode.
+
+---
+
+## Re-Review Flow
+
+Entered from Phase 0 when the current user already commented. **Replaces Phases 1–6.** Worktree setup, posting (Phase 7), and title-icon (Phase 8) machinery still apply. Mental model: the change was already reviewed, the author pushed responses — verify those, don't re-derive everything.
+
+- **R1 — Collect prior state.** Gather every prior comment by the current user (inline + summary), each with its `file:line`, what it flagged, and its original verdict (check `./reviews/pr-review-findings-{n}.md` if it survives). Read author replies. Identify the **delta since last review** (commits after the last comment timestamp; diff `{sha-at-last-review}...HEAD`).
+- **R2 — Resolution check** (per prior comment, by reading the code at the worktree, not trusting reply text): Resolved / Partially resolved / Not resolved / Won't-fix-but-justified. Apply Prime Directive 2 — record an `Already checked:` line for any "not resolved" call.
+- **R3 — Sanity check the delta.** Focused pass (not the full Domain sweep): did fixes introduce regressions or new edge cases? Did unrelated changes sneak in? Quick scan against Domain 0 + obviously-touched domains, changed lines only. New issues → fresh findings (verdict + confidence + anchor).
+- **R4 — Verdict (always user-confirmed).** Per-prior-comment status table + new findings + proposed overall verdict and icon. **Require explicit user confirmation before acting — always, including Auto Mode.** Write under `## Re-review ({date})`, appended below prior content.
+- **R5 — Post & retitle** once confirmed; then offer worktree cleanup.
+
+---
+
+## Artifacts
+
+All file artifacts go in `./reviews/` of the **launch** repo (create if missing), never inside the disposable worktree.
+
+| Artifact | Purpose | Lifecycle |
+|----------|---------|-----------|
+| **Findings file** (`./reviews/pr-review-findings-{n}.md`, or `-local.md`) | Working doc; survives compaction; holds briefing, two-axis pre-pass (kept separate), table with verdict+confidence+anchor, Post? selections. | Updated per domain; persisted to disk. |
+| **Posted comments** | Published output to the author. | Only what the user checked. |
+| **Title icon** (💬/🔴/🟢) | At-a-glance verdict. | Set in Phase 8; replaced on re-review. |
+| **Chat** | Live interrogation. | Don't regurgitate the table after writing the file; don't volunteer an end-of-session summary unless asked. |
+
+---
+
+## Asking Questions (rules)
+
+- **Use `AskUserQuestion`** — never plain-text questions.
+- **First option = recommendation,** with `(Recommended)` in the label.
+- **Batch ≤4, same domain only.** Cross-domain → separate calls.
+- **Every question body MUST include an `Already checked:` line** — the exploration gate made visible.
+- **Include an escape hatch:** an "I don't know — ask the author" option (promotes to Open Question without forcing "Other").
+- **Anchor to `file:line`.** "What happens at `paymentPlan.ts:204` when `last_*` is null?" beats "is null-handling right?"
+- **Loop-break:** user can't answer twice → stop the batch, re-explore.
+
+Tool constraints: 2–4 options, header ≤12 chars, `multiSelect: true` only when options aren't mutually exclusive.
+
+**Fallback (no AskUserQuestion):** `**[Domain] — [Topic] — file:line**` + question + `**My read:**` + `**Already checked:**` + 2–3 lettered options including one "I don't know — promote to comment."
+
+---
+
+## When to Stop
+
+**First review** is complete when: the briefing is agreed; the two-axis pre-pass has run (both reports in the file, or Spec marked "no spec available"); every relevant domain is worked (including pre-pass candidates); every risk hot-spot is a finding, no-finding, or Open Question; every row has Confidence + Verdict + Anchor; Post? is finalized.
+
+**Re-review** is complete when: every prior comment has a resolution status (R2); the delta had its sanity pass (R3); the overall verdict is **explicitly confirmed by the user** (R4) — never skipped.
+
+After that, await explicit instruction to post (or to end without). Then close out: Phase 8 title icon (host modes), then offer to remove the review worktree.

--- a/skills/pr-review/references/exploration-checklist.md
+++ b/skills/pr-review/references/exploration-checklist.md
@@ -1,0 +1,72 @@
+# Exploration Checklist
+
+The procedural enforcement of "exhaust the codebase first." The agent runs this **before** promoting any question to the user OR to the author.
+
+If you cannot fill in the `Already checked:` line for a question, the question is not ready — go back and explore.
+
+---
+
+## Per-Question Checklist
+
+Before surfacing a question, you have:
+
+- [ ] Read the **full function** being changed (not just the diff hunk).
+- [ ] Grepped for **callers of any changed function**, filtering out tests:
+  ```bash
+  grep -rn 'funcName\b' src | grep -vi test
+  ```
+- [ ] If the question is about convention/style: checked the repo's **discovered** convention/instruction files (the Phase-0 Standards sources — `CLAUDE.md`, `CONTRIBUTING.md`, `docs/coding-standards/**`, `docs/**/best_practices*`, etc.) for the keyword.
+- [ ] If the question is about precedent ("should this fire on event X?"): found a **sibling implementation** handling the same kind of thing and read its callsite.
+- [ ] If the question is about project policy (rollback safety, migration pattern, multi-app routing): checked the discovered instruction files and convention docs.
+- [ ] Written the `Already checked:` line. If it's empty, vague, or "I assumed," the checklist isn't complete.
+
+---
+
+## The `Already checked:` Line
+
+Every `AskUserQuestion` body and every Open-Question-for-Author finding must carry this line. Format:
+
+```
+Already checked: <what you did> — <what it told you> — <why it didn't fully answer>
+```
+
+**Good examples:**
+
+> Already checked: grepped `processFirstPayment\b` in `src` — no non-test callers; the real first-payment path is `checkout.ts:handleSeriesEnrollment` (lines 8565, 8599). User judgment needed because both paths exist; need to know whether the dead path's emissions matter.
+
+> Already checked: read the repo's `anti-patterns` doc on "don't re-emit the same event from a higher-level wrapper" + the glossary entry. Pattern says don't double-fire; but this PR's new event is semantically distinct. Need user judgment on whether the docs should note the intentional overlap.
+
+> Already checked: grepped `automation_trigger_group_id` across all migrations — three features use the same NULL-group pattern. Not asking the user; recording as no-finding.
+
+**Bad examples (do NOT surface questions like these):**
+
+> Already checked: nothing — wanted to confirm.
+
+> Already checked: skimmed the file.
+
+> Already checked: I think this looks right but want to be sure.
+
+If the line looks like a "bad example," go back and explore.
+
+---
+
+## When to Promote to an Open Question (for the author)
+
+Only when **all three** hold:
+1. The exploration checklist is complete, AND
+2. The answer genuinely depends on **author intent** or **prior context not in the repo**, AND
+3. You can articulate *why* the codebase doesn't answer it.
+
+If you can't articulate (3), you haven't explored enough.
+
+---
+
+## Loop-Break Rule
+
+If during Phase 4 the user answers "not sure / verify / I don't know" 2+ times in a single `AskUserQuestion` batch:
+
+1. **Stop the batch.** Don't continue with the remaining questions.
+2. **Re-enter exploration.** Use the unresolved items as grep/read targets.
+3. **Return with grounded recommendations** instead of re-asking.
+
+A "verify" answer is a signal that you didn't ground your recommendation in code. Treat it that way.

--- a/skills/pr-review/references/findings-format.md
+++ b/skills/pr-review/references/findings-format.md
@@ -1,0 +1,99 @@
+# Findings Format
+
+The findings file is the working artifact of the review. It survives compaction and is the input to the comment-posting phase.
+
+**Path:** `./reviews/pr-review-findings-{N}.md` (host modes) or `./reviews/pr-review-findings-local.md` (local-branch), in the repo root of the **launch** worktree — never inside the disposable review worktree. Create `./reviews/` if missing.
+
+**Write timing:** create at the end of Phase 1 (briefing agreed). Append the two sub-agent reports under `## Two-Axis Pre-Pass` at the end of Phase 3.5. Update the Findings table at the end of each domain in Phase 4. Finalize after Phase 5 (verdict + confidence assigned).
+
+---
+
+## File Structure
+
+```markdown
+# PR/MR #{n} — {title}
+
+Review session: {date} · Host: `{github|gitlab|local}` · Branch: `{branch}` · Head SHA: `{sha}`
+Standards sources: {discovered files}. Spec source: {discovered spec / issue / "no spec available"}.
+
+---
+
+## What this PR does
+
+{Phase-1 briefing — what / why / how, with system context. Three short paragraphs.}
+
+---
+
+## Two-Axis Pre-Pass
+
+{Phase-3.5 output. Two sub-agent reports, verbatim (lightly cleaned), kept separate — never merged or reranked across axes.}
+
+### Standards
+{Standards sub-agent report — violations of documented conventions, each citing the source file + rule, anchored to file:line.}
+
+### Spec
+{Spec sub-agent report — missing/partial requirements, scope creep, wrong-looking implementations, each quoting the spec/issue line. Or "No spec available."}
+
+_Summary: Standards — N findings (worst: …). Spec — M findings (worst: …)._
+
+---
+
+## Decisions log (per domain)
+{One line per domain explored in Phase 4. Optional — useful for compaction recovery.}
+
+---
+
+## Findings
+
+| # | Category | Severity | Confidence | File:Line | Anchor | Finding | Recommended Action | Verdict | Post? |
+|---|----------|----------|------------|-----------|--------|---------|--------------------|---------|-------|
+| 1 | Bug Risk | High | High | `src/services/checkout.ts:8565` | Summary | Cycle 1 of every recurring plan calls `markCycleSucceeded` but the new `cycle_succeeded` event is never emitted here. Consumers bound to that event silently miss cycle 1. | Emit `cycle_succeeded` after the `markCycleSucceeded` call. | Fix before merge | `[x]` |
+| 2 | Open Question | — | Low | `src/util/paymentPlanCycle.ts:166` | Inline | `getSender()` returns `null` when the row is gone. Downstream dispatcher behavior unverified. | Author: does the dispatcher handle a `null` sender gracefully, or crash? | Verify before merge | `[x]` |
+
+---
+
+## Posting plan
+- Summary review body bundles: {list of summary-anchored findings + intro text}
+- Inline comments: {file:line list}
+```
+
+---
+
+## Column definitions
+
+| Column | Values | Notes |
+|--------|--------|-------|
+| **#** | sequential | Stable across the session. |
+| **Category** | `Bug Risk` / `Edge Case` / `Regression Risk` / `Open Question` / `Style` / `Convention` / `Spec Gap` / `Scope Creep` / `Test Gap` / `Security` / `Perf` / `Doc` | Pick the dominant one. A Standards-axis finding usually becomes `Convention`; a Spec-axis finding becomes `Spec Gap` (missing/wrong) or `Scope Creep` (unasked-for). |
+| **Severity** | `High` / `Medium` / `Low` / `—` | `—` for Open Questions and pure Style. |
+| **Confidence** | `High` / `Medium` / `Low` | High = verified by grep/code reading. Medium = plausible pattern. Low = suspicion, needs the author. |
+| **File:Line** | `path/to/file.ts:NNN` | Tightest anchor possible. Range OK: `file.ts:100-115`. |
+| **Anchor** | `Inline` / `Summary` | Phase 3. `Inline` = file is in the diff. `Summary` = referenced but not in the diff; post via the review body. |
+| **Finding** | One paragraph | What's wrong / surprising. Be specific. No "this might be a problem." |
+| **Recommended Action** | One sentence | What the author should do. For Open Questions, this is the question itself. |
+| **Verdict** | `Fix before merge` / `Reviewer decides` / `Verify before merge` / `Nice-to-have` / `Confirmed safe` | Phase 5. |
+| **Post?** | `[ ]` / `[x]` / `[posted]` | Default `[ ]`. Open Questions default `[x]`. After posting, mark `[posted]`. |
+
+---
+
+## Defaults for Post?
+
+- **Open Questions** → `[x]` (they exist *because* the author must weigh in)
+- **`Fix before merge`** → `[x]`
+- **`Verify before merge`** → `[x]`
+- **`Reviewer decides`** → `[ ]` (user opts in)
+- **`Nice-to-have`** → `[ ]`
+- **`Confirmed safe`** → `[ ]` (working doc only)
+- **Style / hygiene** → `[ ]` (don't drown reviews in nits)
+
+User can override any default in Phase 6.
+
+---
+
+## What goes inline vs. in the summary review
+
+**Inline (Anchor = `Inline`):** the file appears in the diff. Use the host's inline-comment API; cite `file:line` via the native UI.
+
+**Summary (Anchor = `Summary`):** the file is referenced but not in the diff. Inline comments will fail. Bundle these in the top-level review body and reference `file:line` in prose (Markdown code spans).
+
+When in doubt, check Phase 3 classification. If Phase 3 wasn't done for a file, do it now before posting.

--- a/skills/pr-review/references/findings-format.md
+++ b/skills/pr-review/references/findings-format.md
@@ -2,7 +2,7 @@
 
 The findings file is the working artifact of the review. It survives compaction and is the input to the comment-posting phase.
 
-**Path:** `./reviews/pr-review-findings-{N}.md` (host modes) or `./reviews/pr-review-findings-local.md` (local-branch), in the repo root of the **launch** worktree — never inside the disposable review worktree. Create `./reviews/` if missing.
+**Path:** `./reviews/pr-review-findings-{N}.md` (host modes) or `./reviews/pr-review-findings-local.md` (local-branch), in the repo root of the **launch** worktree — never inside the disposable review worktree. Create `./reviews/` if missing. The launch-repo-root `./reviews/` location is a deliberate, target-repo-scoped choice (stack-agnostic) — it belongs to whatever repo is under review, so it is not a doc-placement violation when this skill runs on a repo with its own docs conventions.
 
 **Write timing:** create at the end of Phase 1 (briefing agreed). Append the two sub-agent reports under `## Two-Axis Pre-Pass` at the end of Phase 3.5. Update the Findings table at the end of each domain in Phase 4. Finalize after Phase 5 (verdict + confidence assigned).
 

--- a/skills/pr-review/references/posting-comments.md
+++ b/skills/pr-review/references/posting-comments.md
@@ -46,7 +46,9 @@ JSON
 
 **Resolve project + diff refs** (positions need all three SHAs):
 ```bash
-PROJ=$(git remote get-url origin | sed -E 's#^.*[:/]([^/]+/.+?)(\.git)?$#\1#' | sed 's#/#%2F#g')
+PROJ=$(git remote get-url origin \
+  | sed -E 's#^[a-z]+://[^/]+/##; s#^[^/]+:##; s#\.git$##' \
+  | sed 's#/#%2F#g')
 glab api "projects/$PROJ/merge_requests/{n}" --jq '{base: .diff_refs.base_sha, start: .diff_refs.start_sha, head: .diff_refs.head_sha}'
 ```
 

--- a/skills/pr-review/references/posting-comments.md
+++ b/skills/pr-review/references/posting-comments.md
@@ -1,0 +1,112 @@
+# Posting Comments
+
+Posting happens in **Phase 7**, only on explicit user instruction ("post the comments" or equivalent). Never post on Phase-6 completion. **Skip this file entirely in local mode** — the findings file is the deliverable.
+
+The host was resolved in Phase 0. Use the matching section below.
+
+---
+
+## Pre-flight (both hosts)
+
+1. Confirm the head SHA (used as `commit_id` / required for GitLab positions). Stale SHAs are rejected.
+2. Re-verify Phase-3 anchor classifications. Any file not in the diff is `Summary`-only.
+3. Group findings by Anchor:
+   - **Inline-anchorable** → posted individually on the diff line.
+   - **Summary-only** → bundled into a single top-level review / MR note.
+
+**Severity emoji convention:** 🔴 Fix before merge · 🟡 Verify before merge / Reviewer decides · 🟢 Confirmed safe (only if posting).
+
+---
+
+## GitHub (`gh`)
+
+**Head SHA:** `gh pr view {n} --json headRefOid -q .headRefOid`
+
+**Inline comment** (file is in the diff):
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/comments -X POST --input - <<'JSON'
+{ "commit_id": "<head SHA>", "path": "src/util/paymentPlanCycle.ts", "line": 143, "side": "RIGHT", "body": "..." }
+JSON
+```
+- `line` must appear in the diff (added or context); an unchanged-region line is rejected.
+- `side`: `RIGHT` for added/modified, `LEFT` for deleted. Multi-line: `start_line` + `line` (same side).
+- Failure: "review thread for that diff hunk is missing" → line not in diff, reclassify as `Summary`. "422" → usually a stale SHA; re-fetch and retry.
+
+**Summary review** (files not in the diff, bundled):
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews -X POST --input - <<'JSON'
+{ "commit_id": "<head SHA>", "event": "COMMENT", "body": "<markdown — see body structure>" }
+JSON
+```
+- `event`: `REQUEST_CHANGES` if any `Fix before merge`; `COMMENT` if only verify/decide/open-questions. **Never `APPROVE`** — approval is a human decision.
+
+---
+
+## GitLab (`glab`)
+
+**Resolve project + diff refs** (positions need all three SHAs):
+```bash
+PROJ=$(git remote get-url origin | sed -E 's#^.*[:/]([^/]+/.+?)(\.git)?$#\1#' | sed 's#/#%2F#g')
+glab api "projects/$PROJ/merge_requests/{n}" --jq '{base: .diff_refs.base_sha, start: .diff_refs.start_sha, head: .diff_refs.head_sha}'
+```
+
+**Inline comment** = a discussion pinned to a diff position:
+```bash
+glab api "projects/$PROJ/merge_requests/{n}/discussions" -X POST \
+  -f body="..." \
+  -f position[position_type]=text \
+  -f position[base_sha]=<base> -f position[start_sha]=<start> -f position[head_sha]=<head> \
+  -f position[new_path]=src/util/paymentPlanCycle.ts \
+  -f position[old_path]=src/util/paymentPlanCycle.ts \
+  -f position[new_line]=143
+```
+- `new_line` must be a line on the diff's RIGHT side. For a deleted line use `old_line` instead.
+- Failure (`400 line_code`/position invalid) → the line isn't on the diff; reclassify as `Summary`.
+
+**Summary** = a single MR note (no position):
+```bash
+glab mr note {n} -m "<markdown — see body structure>"
+# or: glab api "projects/$PROJ/merge_requests/{n}/notes" -X POST -f body="..."
+```
+GitLab has no `REQUEST_CHANGES`/`APPROVE` via this skill — convey the verdict in the note body + the title icon (Phase 8). Never run `glab mr approve`.
+
+---
+
+## Summary body structure (both hosts)
+
+```markdown
+{One-sentence intro about the review and its scope.}
+
+---
+
+### 🔴 {Finding title}
+{Finding body, prose-referencing file:line via Markdown code spans.}
+**Required:** {recommended action}
+
+---
+
+### 🟡 {Finding title}
+...
+
+---
+
+Inline comments cover: {brief list of inline anchors}.
+```
+
+---
+
+## After Posting
+
+1. Capture the comment/discussion URLs from the API responses.
+2. Mark each posted row in the findings file: `[x]` → `[posted]`.
+3. Report one line per posted comment (URL + finding #) in chat. Don't repeat the full table.
+
+---
+
+## Edge Cases
+
+- **Local mode / no PR yet:** skip Phase 7. The findings file is the deliverable.
+- **Draft PR/MR:** posting works; confirm the user wants comments visible while drafting.
+- **The author is the user:** self-review comments are valid; confirm they want them visible.
+- **Re-review:** you already read existing comments in Phase 0 — don't post duplicates.
+- **No host CLI / unknown remote:** you should be in local mode; there is nothing to post.

--- a/skills/pr-review/references/review-domains.md
+++ b/skills/pr-review/references/review-domains.md
@@ -1,0 +1,186 @@
+# Review Domains
+
+Domains to interrogate during Phase 4. Stack-agnostic — the grep examples are illustrative; adapt the patterns to the diff's language.
+
+**Order:**
+1. **Domain 0 — Dead Code & Call-Graph Reality Check** (always first; cheap, catches the worst class of bug).
+2. **Domain 1 — Intent Alignment** (always; sets the frame).
+3. **Remaining domains** by relevance to what the diff touches. Skip irrelevant ones.
+
+For each domain: (1) identify the lines/files under it; (2) run the [exploration checklist](exploration-checklist.md), writing the `Already checked:` line; (3) route — codebase answers → record finding; genuine judgment → `AskUserQuestion` (batched); author-intent unknown → Open Question.
+
+**Anti-pattern reminder:** if 30 seconds of grep answers it, do the grep — don't surface the question.
+
+---
+
+## Domain 0: Dead Code & Call-Graph Reality Check (always first)
+
+For every function/path the diff modifies or adds side-effects to, verify it has **live, non-test callers**.
+
+The failure mode this catches: a PR adds an emission, fix, or guard to function `X` — but `X` has no non-test callers, while a different function `Y` is the production path. The change ships, looks correct, and does nothing.
+
+**Questions:**
+- For every modified function: any non-test caller in a production path?
+- For every new emission (analytics event, log, side effect): is the surrounding function actually invoked at runtime?
+- For every guard / early return added: does control flow actually reach it from a live entry point?
+- If the diff says "X is the {checkout / refund / first-payment / …} path," is X actually invoked from a controller, route, cron, webhook, or other live entry?
+
+**Explored evidence (adapt to language):**
+```bash
+# Live callers of a symbol, excluding tests
+grep -rn 'processFirstPayment\b' src --include='*.ts' | grep -vi test
+
+# Live entry points calling into changed code
+grep -rn 'changedFunction\b' src/controllers src/routes src/cron src/webhooks 2>/dev/null
+
+# Nothing comes back? The change may be on a dead path — search for the sibling that IS live:
+grep -rn 'similarFunctionName\b' src | grep -vi test
+```
+
+**Promotion:** if the function is dead, that itself is a finding (severity Medium+, anchored on the dead function; recommended action: identify the real path and apply the change there).
+
+---
+
+## Domain 1: Intent Alignment (always; sets the frame)
+
+What is this change *trying* to do, and does the diff actually do that?
+- What does the title / body / linked issue / spec claim?
+- What does the diff actually change? (Your read.)
+- Where does claimed intent diverge from actual changes?
+- Changes unexplained by the stated intent? Parts of the intent missing from the diff?
+
+**Explored evidence:** title/body, commit messages, linked issue/spec (Phase-0 discovery), branch name.
+
+**Output rule:** the agreed "What this PR does" briefing (Phase 1) is canonical. Any unresolved divergence becomes an Open Question.
+
+---
+
+## Domain 2: Bug Risk in the Diff
+
+Line-by-line: what can break?
+- Null / undefined / `None` paths not guarded
+- Off-by-one, boundary conditions, empty / single-element collections
+- Async ordering, races, double-fire, missed `await` / unhandled promise
+- Error swallowing (`catch {}` with no rethrow, returning `null`/`nil` on failure)
+- Side effects in the wrong order (write before validation, etc.)
+- Money / currency math (cents vs units, fee calc, rounding)
+- Auth / permission gaps (missing role check, wrong tenant filter)
+- New code paths that bypass existing invariants
+
+**Explored evidence:** read full functions (not hunks). Read immediate callers. Check the repo's discovered anti-pattern/convention docs for known traps.
+
+**Promotion:** escalate to Open Question only if the invariant truly can't be confirmed from the repo. Trace call sites first — if every caller demonstrably passes non-null, record a finding (or no-finding).
+
+---
+
+## Domain 3: Edge Cases & Inputs Not Covered
+
+What inputs/states does this code not handle?
+- Parent entity in an unusual state (paused, refunded, deleted, archived)
+- Retry / replay: is the operation idempotent?
+- Concurrency: two users, two tabs, two cron firings
+- Empty / max / negative / unicode / malformed inputs
+- Upstream slow / down / 4xx / 5xx
+
+**Explored evidence:** look for guards, early returns, validation. Identify which inputs flow through unchecked.
+
+---
+
+## Domain 4: Regression Risk (Things Not in the Diff)
+
+What does this change affect that isn't visible in the diff?
+- Callers of functions whose signature/behavior changed
+- Code reading a field/column whose semantics changed
+- Cron jobs, webhooks, scheduled tasks touching the same data
+- Existing tests that pass but no longer assert what they claim
+- Cached data now stale (Redis, materialized views, in-memory, CDN)
+- **Sibling functions that should have received the same change but didn't** (the Domain-0 dead-code case has a twin here: live code doing the same thing as the modified function, not updated)
+
+**Explored evidence:**
+```bash
+grep -rn 'changedFunction\b' src | grep -vi test          # callers
+grep -rn 'markCycleSucceeded\|markCycleFailed' src | grep -vi test   # siblings
+```
+
+**Promotion:** don't ask "did you check caller X?" — check it yourself. `grep`, record a concrete risk or note no-finding. Escalate only when reading the caller doesn't reveal whether the change is safe.
+
+---
+
+## Domain 5: Data / Schema Migration Safety (skip if no migration)
+
+For diffs touching migrations / schema (`migrations/`, `prisma/`, `drizzle/`, `*.sql`, ORM schema files):
+- Backward-compatible with code already running in prod (expand-contract)?
+- Does pre-deploy code still work against the new schema?
+- Rollback survival: does data stay intact if reverted?
+- `NOT NULL` adds, type narrowings, column/table removals → staged?
+- Locks on large tables that could block prod traffic?
+- Paired metadata/permission changes applied together?
+
+**Explored evidence:** read the migration top-to-bottom; read accompanying metadata diffs; check precedents in the migrations dir for the same kind of operation.
+
+---
+
+## Domain 6: API / Contract Changes
+
+For diffs touching public contracts — REST/GraphQL/gRPC endpoints, exported library functions, queue message shapes, webhook payloads:
+- Backward-compatible for live clients/consumers? (removed/renamed field, narrowed type, new required input)
+- New read/write permissions scoped correctly? (a silent `null`/empty return is a permission fail in disguise)
+- Polymorphic / discriminated payloads resolved correctly?
+- Input validation present at the boundary? Admin/system-level operations gated?
+- Versioning honored if the contract is versioned?
+
+**Explored evidence:** read the changed schema/contract files. Cross-check that every newly-queried field is actually exposed/permitted. Check the repo's discovered API conventions.
+
+---
+
+## Domain 7: Tests — What's Covered, What's Not
+
+- Does the change include tests? Unit, integration, or both?
+- Do tests exercise the risky paths, or just the happy path?
+- Placeholder tests (mocks compared to themselves, only "it renders" asserted)?
+- Integration tests hitting real deps vs mocking the critical path?
+- What's untested that should be? (Tie back to Domain 2/3 findings.)
+
+**Explored evidence:** read new/changed test files. Diff them against the production logic.
+
+**Promotion:** "should this path have a test?" is sometimes a judgment call — ask the user, fall back to Open Question.
+
+---
+
+## Domain 8: Logging, Observability & Operations
+
+- Logging on new failure paths? Structured and useful?
+- Anything sensitive logged (tokens, full PII, raw payment data)?
+- Background work: would we notice if it silently stopped?
+- New analytics/events firing the right type, not double-firing one a lower layer already emits?
+- Is a rollback observable — would we know to roll back if this misbehaves?
+
+**Explored evidence:** `grep` for the repo's logger / event helpers in the diff. Check catch blocks: do they log before swallowing?
+
+---
+
+## Domain 9: Conventions & Codebase Hygiene
+
+Lighter pass — flag clear violations, not stylistic preference. **This domain consumes the Standards-axis findings from the Phase 3.5 pre-pass.**
+- Anti-patterns from the repo's discovered convention/instruction files
+- Hardcoded values that should be constants/config
+- Dead code, commented-out blocks, TODOs referencing this change
+- Comments referencing "this PR" / "the previous version" (rot fast)
+- Naming inconsistent with the repo's glossary/domain terms
+
+**Batching:** hygiene findings rarely need user input — record directly, severity Low. **Posting default `[ ]`** — don't drown a review in nits.
+
+---
+
+## Domain 10: Security & Privacy (always at least a quick scan)
+
+- New endpoints: authn + authz present?
+- User input flowing into SQL / shell / HTML / template without sanitization?
+- Secrets / tokens / keys in code, logs, or fixtures?
+- Cross-tenant data leakage (org A reading org B's data)?
+- New permissions / role grants — least privilege?
+- Webhook / callback endpoints: signature verification?
+
+**Explored evidence:** skim the diff for `req.body`/`req.query`, raw SQL strings, `process.env`/`os.environ`, new route handlers. Trace the auth chain.
+
+**Promotion:** don't pre-emptively escalate a suspected vuln — trace first. Most "can A read B's data?" questions are answerable by reading the auth chain. Escalate only when the path depends on context outside the repo.


### PR DESCRIPTION
## What

Adds a **`pr-review`** skill — a two-axis (**Standards ⊥ Spec**), stack-agnostic **deep code-review** skill for a pull/merge request or a local diff — plus a thin **`/v:pr-review`** command in the `/v:*` family that runs it.

**Review-only** — it never edits, commits, pushes, or merges code.

## Why

Compound V orchestrates *writing* changes (partition → dispatch → 3-pass review gate). This adds a focused, standalone **PR/diff review** capability contributors can invoke directly (`/v:pr-review <PR>`, or empty = current branch vs. its base). It complements `/v:review-plan` (which reviews a *plan* before dispatch) with a review of the *resulting diff*.

## How it works

- Builds shared understanding of the change's intent, then hunts bugs / edge cases along two deliberately separate, context-isolated axes:
  - **Standards** — conformance to *this repo's* documented conventions (Phase-0 discovery).
  - **Spec** — faithful implementation of the originating spec / issue / PRD.
- Findings are reported **side by side** (never merged across axes); genuine author-intent unknowns become Open Questions; every finding carries a **verdict + confidence**.
- Host-agnostic: GitHub (`gh`), GitLab (`glab`), or a hostless local branch.

## Contents

- `skills/pr-review/SKILL.md` + 4 `references/` (exploration checklist, review domains, findings format, comment-posting)
- `commands/v-pr-review.md` — namespaced `/v:*` entry point
- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` bumped `2.5.5 → 2.6.0` (version lockstep)
- `CHANGELOG.md` entry for 2.6.0

## Conventions / gates (verified locally)

- ✅ `scripts/lint-frontmatter.py` clean (description length, no-Haiku, valid YAML)
- ✅ `plugin.json` / `marketplace.json` valid JSON + versions in lockstep (2.6.0)
- ✅ all intra-plugin `.md` cross-refs resolve (dead-link gate)
- ✅ no new runtime deps, hooks, or scripts

> Note: the skill's `description` originally read `Review-only: never edits code` — the `: ` (colon-space) trips the repo's strict `yaml.safe_load` linter, so it was changed to an em-dash (`Review-only — never edits code`) to match the repo's frontmatter style. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
