### PR TITLE
fix(fastpath+emit): one interpreter for the test floor, and honour its verdict

### DIFF
--- a/scripts/compound-v-emit-workflow.py
+++ b/scripts/compound-v-emit-workflow.py
@@ -4335,6 +4335,7 @@ def external_session_id(run_dir, job_id):
 
 
 def _job_result_from(verdict, job, state_job, tests=None, contract=None,
+                     contract_declared=False,
                      isolation=None, tier=None):
     """The canonical job_result. Enforcement fields come from the GATE, not the
     implementer: `blocked`, `files_changed` and `violations` are git-derived.
@@ -4387,6 +4388,7 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
     # `blocked`, not `error`: nothing is broken about the machinery, the job's work
     # did not pass its own declared tests. Same class as an out-of-lane write, for
     # the same reason — the work is refused, not the pipeline.
+    result_summary_suffix = ""
     tests_block = _tests_block_from_floor(tests, contract, job, tier) if tests else None
     if status == "success" and isinstance(tests_block, dict):
         t_exit = tests_block.get("exit_code")
@@ -4398,6 +4400,48 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
             # finalizer reads `status` and refused correctly, but every other
             # consumer of the boolean got the opposite conclusion.
             pass
+
+    # A CONTRACTED FLOOR THAT RESOLVED TO NO COMMAND IS NOT A PASS.
+    #
+    # `run_test_floor` initialises every result `{"passed": False, "merge_blocked":
+    # True}` — refusal is the floor's default state — and ADR 0003 relies on it:
+    # "already merge-blocking and already fail-closed on an empty command", with
+    # Consequences: "A job reporting no test command at all is a FAIL, not a pass."
+    # `spec-reviewer.md` enforces that in prose (ISSUE: NO_TEST_EVIDENCE, "Silence
+    # is not success").
+    #
+    # The fast path's own consumer honours it (`build_review_spec` gate 1 refuses on
+    # `not passed or merge_blocked`). THIS consumer did not: it reads the floor only
+    # through `_tests_block_from_floor`, which returns None when no check carries a
+    # `checker`, so `merge_blocked: True` was never consulted and the job kept the
+    # scope verdict's `success`. One floor document, two consumers, opposite
+    # conclusions. Dogfood 14 moved the RED half of the rule from prose into this
+    # function; this is the empty half, at the same layer, for the same reason.
+    #
+    # The predicate is the MANIFEST's declaration, not the resolved slice. `contract`
+    # above is read from `jobs/<id>.test-contract.json`, which does not exist when
+    # resolution FAILED — precisely the case that must be caught. Keying on it would
+    # leave the reachable hole open.
+    #
+    # Unchanged: an uncontracted manifest still records `success` with no `tests`
+    # object — "no floor at all is not a failure".
+    if status == "success" and tests_block is None and contract_declared:
+        if tests is None:
+            # No floor document at all: `fastpath-run.py` was absent or died before
+            # writing JSON. The machinery IS broken here, so `error`, not `blocked`.
+            status = "error"
+        else:
+            status = "blocked"
+        _floor_reasons = [str(r) for r in ((tests or {}).get("reasons") or []) if r]
+        if _floor_reasons:
+            # Without this the refusal carries no cause: the floor's own
+            # "test contract did not resolve (fail-closed): ..." is dropped and the
+            # summary falls back to the job title, which is a refusal for an
+            # unstated reason.
+            result_summary_suffix = "; ".join(_floor_reasons[:3])
+        else:
+            result_summary_suffix = ("the manifest declares a test_contract but the "
+                                     "floor resolved to no command")
 
     # The three REQUIRED fields below are typed `string`/`string`/`integer` in the
     # schema, with the empty string and 0 documented as their own "not applicable"
@@ -4436,7 +4480,8 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
         "violations": violations,
         "summary": (("implementer returned no result (turn cap or crash); the registered "
                      "worktree was gated as evidence — " if _impl_no_result else "")
-                    + (verdict.get("reason") or (job.get("title") or job.get("id") or ""))),
+                    + (verdict.get("reason") or (job.get("title") or job.get("id") or ""))
+                    + (" - " + result_summary_suffix if result_summary_suffix else "")),
         "session_id": state_job.get("session_id") or "",  # filled from the events log for an external job (finding 81)
         "worktree": worktree,
         "exit_code": exit_code,
@@ -4712,8 +4757,14 @@ def cmd_record(argv):
 
             state_job["session_id"] = _ext_sid
 
+    # Whether the MANIFEST declared a floor — not whether the slice resolved. The
+    # slice is absent exactly when resolution failed, which is the case that must
+    # not pass silently. Mirrors `declares_contract` in build_plan.
+    _contract_declared = isinstance(manifest.get("test_contract"), dict) and bool(
+        manifest.get("test_contract"))
     result = _job_result_from(verdict, job, state_job, tests=tests,
-                              contract=contract, isolation=isolation, tier=tier)
+                              contract=contract, isolation=isolation, tier=tier,
+                              contract_declared=_contract_declared)
 
     # ---- the workflow's retry log ------------------------------------------
     # It lands in state.json and in this ack, NOT as a new top-level key on the
@@ -6218,6 +6269,48 @@ def selftest():
                                      "write_allowed": ["docs/x/**"]}, {})
         _check("no floor at all is not a failure",
                _jr_none["status"] == "success")
+
+        # A CONTRACTED floor that resolved to NO COMMAND must not pass.
+        # `_tests_block_from_floor` returns None for an empty `checks` list, so the
+        # red-floor rule above cannot see it and the job kept the scope verdict's
+        # `success` — while the floor document itself said `merge_blocked: True`.
+        _empty_floor = {"phase": "test_floor", "tier_used": 0, "passed": False,
+                        "merge_blocked": True, "checks": [],
+                        "reasons": ["test contract did not resolve (fail-closed)"]}
+        _jr_empty = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=_empty_floor, contract_declared=True)
+        _check("a CONTRACTED floor that resolved to no command is blocked",
+               _jr_empty["status"] == "blocked", str(_jr_empty["status"]))
+        _check("...and it carries no fabricated tests block",
+               "tests" not in _jr_empty or _jr_empty.get("tests") in (None, {}))
+        _check("...and the refusal states the floor's OWN reason",
+               "did not resolve" in (_jr_empty.get("summary") or ""),
+               str(_jr_empty.get("summary")))
+        # The predicate is the MANIFEST's declaration, not the resolved slice: the
+        # slice is missing exactly when resolution failed, so keying on it would
+        # leave the reachable hole open.
+        _jr_slice = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=_empty_floor, contract={}, contract_declared=True)
+        _check("a declared contract whose SLICE is missing is still caught",
+               _jr_slice["status"] == "blocked", str(_jr_slice["status"]))
+        # No floor document at all is broken machinery, not a refused job.
+        _jr_nodoc = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=None, contract_declared=True)
+        _check("a contracted job whose floor produced NO document is error",
+               _jr_nodoc["status"] == "error", str(_jr_nodoc["status"]))
+        # The narrowness is the point: no contract, no obligation.
+        _jr_nocontract = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=_empty_floor)
+        _check("an UNcontracted job with no floor evidence still passes",
+               _jr_nocontract["status"] == "success", str(_jr_nocontract["status"]))
 
         _check("a lane-declaring job with no observable worktree is RECORDED",
                rc_nw == 0 and isinstance(nw_res, dict), str(rc_nw))

--- a/scripts/compound-v-fastpath-run.py
+++ b/scripts/compound-v-fastpath-run.py
@@ -222,6 +222,56 @@ def _git(worktree, args, timeout_s=GIT_TIMEOUT_S, cap_bytes=MAX_DIFF_BYTES):
     return _run_supervised(["git", "-C", worktree] + list(args), None, timeout_s, cap_bytes)
 
 
+# A `test_contract` command is a COMMAND, and a manifest author writes one the way
+# they would type it: with a glob, a `$(...)`, an `&&` chain. `shlex.split` + argv
+# exec turns every one of those into a LITERAL argument --
+# `node --test $(ls test/*.test.js) && swiftc …` becomes
+# ['node','--test','$(ls','test/*.test.js)','&&','swiftc',…] and exits 1 -- which in
+# the receipt is indistinguishable from a genuinely failing suite. So a string that
+# carries shell syntax is run BY a shell; a plain-argv string keeps the faster,
+# quote-exact argv path it has always had.
+#
+# POSIX-sh metacharacters only (no brace expansion, no `~`): every one of these
+# changes what the string MEANS, and `/bin/sh` is what the author was writing for.
+_SHELL_META = frozenset("$`&|;<>()*?[\n")
+
+
+def _test_command_argv(raw):
+    """``(argv, spelling, via_shell)`` for one configured test command.
+
+    ``spelling`` stays the ORIGINAL string: `" ".join(shlex.split(x))` is lossy --
+    `sh -c "exit 0"` comes back as `sh -c exit 0`, a different command -- and B2
+    recomputes the next run's "previously failing" set from these strings.
+    """
+    if not isinstance(raw, str):
+        cmd = list(raw)
+        return cmd, " ".join(shlex.quote(part) for part in cmd), False
+    if any(ch in _SHELL_META for ch in raw):
+        return ["/bin/sh", "-c", raw], raw, True
+    return shlex.split(raw), raw, False
+
+
+TEST_OUTPUT_TAIL_BYTES = 2000
+
+
+def _output_tail(out, cap=TEST_OUTPUT_TAIL_BYTES):
+    """The last ``cap`` bytes of a command's captured stdout, decoded lossily.
+
+    The receipt used to record only `rc=1`, so a failing floor said nothing about
+    WHICH command failed or why, and a broken command was indistinguishable from a
+    broken test. `_run_supervised` already captures bounded stdout and the caller
+    discarded it (`rc, _ = …`). Note the supervisor discards stderr, so this is the
+    stdout tail only -- honest about what it is rather than claiming full output.
+    """
+    if not out:
+        return ""
+    if isinstance(out, bytes):
+        out = out[-cap:].decode("utf-8", "replace")
+    else:
+        out = out[-cap:]
+    return out.strip()
+
+
 # --------------------------------------------------------------------------- #
 # Digests (anti-stale-replay binding; same prefixed-sha256 shape as the receipt).
 # --------------------------------------------------------------------------- #
@@ -1165,29 +1215,38 @@ def run_test_floor(worktree, baseline="HEAD", changed_paths=None, test_cmd=None,
         # that cannot be re-run silently drops coverage instead of restoring it.
         argvs = []
         for raw in resolved:
-            cmd = shlex.split(raw) if isinstance(raw, str) else list(raw)
+            if isinstance(raw, str) and not raw.strip():
+                result["reasons"].append(
+                    "tier-1: configured test command is empty (fail-closed)")
+                return result
+            cmd, spelling, via_shell = _test_command_argv(raw)
             if not cmd:
                 result["reasons"].append(
                     "tier-1: configured test command is empty (fail-closed)")
                 return result
-            spelling = raw if isinstance(raw, str) else " ".join(
-                shlex.quote(part) for part in cmd)
-            argvs.append((cmd, spelling))
+            argvs.append((cmd, spelling, via_shell))
         failed_cmds = []
-        for cmd, spelling in argvs:
-            rc, _ = _run_supervised(cmd, worktree, test_timeout_s)
-            result["checks"].append({"tier": 1, "checker": spelling, "rc": rc,
-                                     "status": "pass" if rc == 0 else "fail"})
+        for cmd, spelling, via_shell in argvs:
+            rc, out = _run_supervised(cmd, worktree, test_timeout_s)
+            check = {"tier": 1, "checker": spelling, "rc": rc,
+                     "status": "pass" if rc == 0 else "fail"}
+            if via_shell:
+                check["via"] = "sh -c"
+            tail = _output_tail(out) if rc != 0 else ""
+            if tail:
+                check["output_tail"] = tail
+            result["checks"].append(check)
             if rc != 0:
-                failed_cmds.append((spelling, rc))
+                failed_cmds.append((spelling, rc, tail))
         if not failed_cmds:
             result["passed"] = True
             result["merge_blocked"] = False
         else:
-            for name, rc in failed_cmds:
+            for name, rc, tail in failed_cmds:
                 result["reasons"].append(
-                    "tier-1: configured tests failed (rc=%s%s): %s"
-                    % (rc, "; timeout" if rc == 124 else "", name))
+                    "tier-1: configured tests failed (rc=%s%s): %s%s"
+                    % (rc, "; timeout" if rc == 124 else "", name,
+                       ("\n%s" % tail) if tail else ""))
         # rc==124 is the supervisor's own timeout signal (never a checker's own exit
         # code — see `_run_supervised`). The identifier gets a distinct label because
         # "sh -c 'sleep 2'" alone does not say WHY it failed, and this is the only
@@ -1197,7 +1256,7 @@ def run_test_floor(worktree, baseline="HEAD", changed_paths=None, test_cmd=None,
         result["failures"] = [
             ("timeout after %s s: %s" % (int(test_timeout_s), name)) if rc == 124
             else name
-            for name, rc in failed_cmds]
+            for name, rc, _tail in failed_cmds]
         return result
 
     # Tiers 2 and 3 cannot work without the diff (soft; fail-closed if underivable).
@@ -1994,6 +2053,43 @@ def _selftest():
         # 2b. tier-1 empty command string → fail-closed.
         res = run_test_floor(r, "HEAD", changed_paths=["a.py"], test_cmd="   ")
         expect("tier-1 empty test command → merge_blocked", res["merge_blocked"] is True)
+
+        # 2c. SHELL SYNTAX IS HONOURED, not tokenised into literal argv.
+        # Each of these three is a DISCRIMINATOR: under the old shlex.split+argv
+        # path it produced the opposite verdict, which is why a floor with a glob
+        # or an `&&` chain read as "my tests are failing".
+        expect("plain argv command stays on the argv path",
+               _test_command_argv("npm test") == (["npm", "test"], "npm test", False))
+        _argv, _spell, _viash = _test_command_argv("node --test $(ls t/*.js) && x")
+        expect("shell syntax routes through sh -c",
+               _viash and _argv[:2] == ["/bin/sh", "-c"]
+               and _argv[2] == "node --test $(ls t/*.js) && x")
+        expect("the ORIGINAL string is kept as the spelling",
+               _spell == "node --test $(ls t/*.js) && x")
+        # `&&` must actually chain: argv-exec ran only the first command and passed.
+        res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
+                             test_cmd="sh -c 'exit 0' && sh -c 'exit 1'")
+        expect("&& chain: a later failure blocks (argv-exec passed it)",
+               res["merge_blocked"] is True)
+        # `||` must actually chain: argv-exec ran only the first and blocked.
+        res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
+                             test_cmd="sh -c 'exit 1' || sh -c 'exit 0'")
+        expect("|| chain: the fallback passes (argv-exec blocked it)",
+               res["passed"] is True)
+
+        # 2d. A FAILING floor records the command's output, not just `rc=N`.
+        # Eight dispatch attempts were spent on a receipt that said only "rc=1".
+        res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
+                             test_cmd="sh -c 'echo BOOM; exit 3'")
+        _t1 = [c for c in res["checks"] if c.get("tier") == 1]
+        expect("failing floor records rc and the stdout tail",
+               bool(_t1) and _t1[0]["rc"] == 3
+               and "BOOM" in _t1[0].get("output_tail", ""))
+        expect("the failure REASON carries the output too",
+               any("BOOM" in reason for reason in res["reasons"]))
+        expect("_output_tail is bounded and stripped",
+               _output_tail(b"x" * 5000) == "x" * TEST_OUTPUT_TAIL_BYTES
+               and _output_tail(b"") == "")
 
         # 3. tier-2 Python parse-check: valid file → pass; broken file → fail.
         r = new_repo("t2-py")

--- a/scripts/compound-v-fastpath-run.py
+++ b/scripts/compound-v-fastpath-run.py
@@ -107,6 +107,7 @@ import argparse
 import datetime as _dt
 import fnmatch
 import hashlib
+import importlib.util
 import json
 import os
 import shlex
@@ -184,19 +185,27 @@ def _supervisor_path():
     return os.path.join(_script_dir(), "compound-v-run-with-timeout.py")
 
 
-def _run_supervised(cmd, cwd, timeout_s, cap_bytes=MAX_OUTPUT_BYTES):
+def _run_supervised(cmd, cwd, timeout_s, cap_bytes=MAX_OUTPUT_BYTES,
+                    capture_stderr=False):
     """Run ``cmd`` (a list) under the timeout supervisor, capturing bounded stdout.
     Returns ``(rc, stdout_bytes)``: ``rc`` is the command's own exit code (or 124 on
-    timeout, 127 if missing). stdin is DEVNULL (enforced by the supervisor AND here);
-    stderr is discarded. Never raises — a supervisor launch failure degrades to a
-    fail-closed non-zero rc."""
+    timeout, 127 if missing). stdin is DEVNULL (enforced by the supervisor AND here).
+    Never raises — a supervisor launch failure degrades to a fail-closed non-zero rc.
+
+    ``capture_stderr`` appends the child's bounded stderr to the returned bytes. It is
+    OFF by default because `_git` and friends want stdout they can parse. The test
+    floor turns it ON: a BROKEN COMMAND (sh syntax error, module-not-found,
+    `ls: cannot access`) reports on stderr and nothing else, so without it the
+    receipt for the very case this diagnostic exists for is still just `rc=N`."""
     tmp = tempfile.mkdtemp(prefix="cv-h1-")
     try:
         outf = os.path.join(tmp, "out")
+        errf = os.path.join(tmp, "err")
         full = [
             sys.executable, _supervisor_path(),
             "--timeout", str(int(max(1, timeout_s))), "--grace", "1",
             "--stdout", outf, "--max-output-bytes", str(int(cap_bytes)),
+        ] + (["--stderr", errf] if capture_stderr else []) + [
             "--",
         ] + list(cmd)
         try:
@@ -213,6 +222,14 @@ def _run_supervised(cmd, cwd, timeout_s, cap_bytes=MAX_OUTPUT_BYTES):
                 data = fh.read()
         except OSError:
             data = b""
+        if capture_stderr:
+            try:
+                with open(errf, "rb") as fh:
+                    err = fh.read()
+            except OSError:
+                err = b""
+            if err:
+                data = (data + b"\n" if data else b"") + b"[stderr] " + err
         return rc, data
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -242,26 +259,57 @@ def _test_command_argv(raw):
     ``spelling`` stays the ORIGINAL string: `" ".join(shlex.split(x))` is lossy --
     `sh -c "exit 0"` comes back as `sh -c exit 0`, a different command -- and B2
     recomputes the next run's "previously failing" set from these strings.
+
+    An unbalanced quote makes `shlex.split` raise; that returns an EMPTY argv so the
+    caller fails closed with a reason, rather than the whole floor dying on a
+    traceback.
     """
     if not isinstance(raw, str):
         cmd = list(raw)
         return cmd, " ".join(shlex.quote(part) for part in cmd), False
     if any(ch in _SHELL_META for ch in raw):
         return ["/bin/sh", "-c", raw], raw, True
-    return shlex.split(raw), raw, False
+    try:
+        return shlex.split(raw), raw, False
+    except ValueError:
+        return [], raw, False
 
 
 TEST_OUTPUT_TAIL_BYTES = 2000
 
 
-def _output_tail(out, cap=TEST_OUTPUT_TAIL_BYTES):
-    """The last ``cap`` bytes of a command's captured stdout, decoded lossily.
+def _redact_output(text):
+    """Redact secret-shaped strings using the CANONICAL families, or drop the text.
 
-    The receipt used to record only `rc=1`, so a failing floor said nothing about
-    WHICH command failed or why, and a broken command was indistinguishable from a
-    broken test. `_run_supervised` already captures bounded stdout and the caller
-    discarded it (`rc, _ = …`). Note the supervisor discards stderr, so this is the
-    stdout tail only -- honest about what it is rather than claiming full output.
+    The floor's captured output is written into `receipts/<id>.gate.json`, which the
+    wave finalizer `git add`s -- so it is durable and committed. Test output routinely
+    carries env dumps and tokenised URLs, and nothing else on this path redacts. The
+    patterns are imported from compound-v-memory.py rather than re-spelled here (the
+    repo forbids a second copy). If that import is unavailable, the text is DROPPED:
+    no diagnostic is worth committing an unredacted credential.
+    """
+    try:
+        engine = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              "compound-v-memory.py")
+        spec = importlib.util.spec_from_file_location("cv_memory_redact", engine)
+        cv_memory = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cv_memory)
+        return cv_memory.redact(text)
+    except Exception:  # noqa: BLE001 -- fail closed: no redactor, no stored output
+        return "[output withheld: redaction engine unavailable]"
+
+
+def _output_tail(out, cap=TEST_OUTPUT_TAIL_BYTES):
+    """A bounded, redacted excerpt of a failing command's captured output.
+
+    HONEST ABOUT WHAT THIS IS. The supervisor keeps the HEAD of each stream up to
+    `--max-output-bytes` (256 KiB) and drops the overflow, so for a suite that prints
+    more than that this is the tail of the FIRST 256 KiB, not the tail of the run --
+    the final summary of a very chatty suite will not be here.
+
+    The receipt used to record only `rc=1`, which is indistinguishable from a
+    genuinely failing suite; `_run_supervised` already captured this and the caller
+    discarded it (`rc, _ = …`).
     """
     if not out:
         return ""
@@ -269,7 +317,7 @@ def _output_tail(out, cap=TEST_OUTPUT_TAIL_BYTES):
         out = out[-cap:].decode("utf-8", "replace")
     else:
         out = out[-cap:]
-    return out.strip()
+    return _redact_output(out.strip())
 
 
 # --------------------------------------------------------------------------- #
@@ -1227,11 +1275,12 @@ def run_test_floor(worktree, baseline="HEAD", changed_paths=None, test_cmd=None,
             argvs.append((cmd, spelling, via_shell))
         failed_cmds = []
         for cmd, spelling, via_shell in argvs:
-            rc, out = _run_supervised(cmd, worktree, test_timeout_s)
+            rc, out = _run_supervised(cmd, worktree, test_timeout_s,
+                                      capture_stderr=True)
             check = {"tier": 1, "checker": spelling, "rc": rc,
                      "status": "pass" if rc == 0 else "fail"}
             if via_shell:
-                check["via"] = "sh -c"
+                check["via"] = "/bin/sh -c"
             tail = _output_tail(out) if rc != 0 else ""
             if tail:
                 check["output_tail"] = tail
@@ -1242,11 +1291,18 @@ def run_test_floor(worktree, baseline="HEAD", changed_paths=None, test_cmd=None,
             result["passed"] = True
             result["merge_blocked"] = False
         else:
-            for name, rc, tail in failed_cmds:
+            for name, rc, _tail in failed_cmds:
+                # The captured output lives on `checks[].output_tail` and NOWHERE
+                # ELSE. It must never reach `reasons`: the emitter copies any reason
+                # matching "timeout after" into `tests.failures[]`
+                # (compound-v-emit-workflow.py), `previously_failing()` reads that
+                # back, and `resolve_test_commands` RE-RUNS those strings. Appending
+                # command output here would let a test's own stdout choose the next
+                # run's commands -- and since a configured command now goes through
+                # a shell, that is command execution, not just noise.
                 result["reasons"].append(
-                    "tier-1: configured tests failed (rc=%s%s): %s%s"
-                    % (rc, "; timeout" if rc == 124 else "", name,
-                       ("\n%s" % tail) if tail else ""))
+                    "tier-1: configured tests failed (rc=%s%s): %s"
+                    % (rc, "; timeout" if rc == 124 else "", name))
         # rc==124 is the supervisor's own timeout signal (never a checker's own exit
         # code — see `_run_supervised`). The identifier gets a distinct label because
         # "sh -c 'sleep 2'" alone does not say WHY it failed, and this is the only
@@ -2079,17 +2135,43 @@ def _selftest():
 
         # 2d. A FAILING floor records the command's output, not just `rc=N`.
         # Eight dispatch attempts were spent on a receipt that said only "rc=1".
+        # The marker is in the command's OUTPUT but never in the command's TEXT, so
+        # the "reason carries no output" assertion below cannot pass by accident.
+        write(r, "boom.txt", "TAILMARKER\n")
+        git(r, ["add", "-A"]); git(r, ["commit", "-qm", "boom"])
         res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
-                             test_cmd="sh -c 'echo BOOM; exit 3'")
+                             test_cmd="sh -c 'cat boom.txt; exit 3'")
         _t1 = [c for c in res["checks"] if c.get("tier") == 1]
         expect("failing floor records rc and the stdout tail",
                bool(_t1) and _t1[0]["rc"] == 3
-               and "BOOM" in _t1[0].get("output_tail", ""))
-        expect("the failure REASON carries the output too",
-               any("BOOM" in reason for reason in res["reasons"]))
+               and "TAILMARKER" in _t1[0].get("output_tail", ""))
+        # …and the REASON must NOT: the emitter copies a reason matching
+        # "timeout after" into tests.failures[], previously_failing() reads it back
+        # and resolve_test_commands RE-RUNS it. Command output in a reason is a path
+        # from a test's stdout to the next run's shell.
+        expect("the failure reason NEVER carries command output (it is re-run)",
+               all("TAILMARKER" not in reason for reason in res["reasons"]))
         expect("_output_tail is bounded and stripped",
                _output_tail(b"x" * 5000) == "x" * TEST_OUTPUT_TAIL_BYTES
                and _output_tail(b"") == "")
+        expect("_output_tail redacts secret-shaped output before it is stored",
+               "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+               not in _output_tail(
+                   b"token=sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+
+        # 2e. A BROKEN COMMAND reports on stderr and says nothing on stdout. That is
+        # the case the receipt existed to disambiguate, so stderr must be captured.
+        res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
+                             test_cmd="sh -c 'echo NOPE >&2; exit 4'")
+        _t1e = [c for c in res["checks"] if c.get("tier") == 1]
+        expect("a stderr-only failure still produces a diagnostic tail",
+               bool(_t1e) and _t1e[0]["rc"] == 4
+               and "NOPE" in _t1e[0].get("output_tail", ""))
+
+        # 2f. An unbalanced quote makes shlex.split raise: fail closed, no traceback.
+        res = run_test_floor(r, "HEAD", changed_paths=["a.py"], test_cmd="pytest 'unclosed")
+        expect("unbalanced quote → merge_blocked, not a crash",
+               res["merge_blocked"] is True)
 
         # 3. tier-2 Python parse-check: valid file → pass; broken file → fail.
         r = new_repo("t2-py")

--- a/scripts/compound-v-fastpath-run.py
+++ b/scripts/compound-v-fastpath-run.py
@@ -239,54 +239,64 @@ def _git(worktree, args, timeout_s=GIT_TIMEOUT_S, cap_bytes=MAX_DIFF_BYTES):
     return _run_supervised(["git", "-C", worktree] + list(args), None, timeout_s, cap_bytes)
 
 
-# A `test_contract` command is a COMMAND, and a manifest author writes one the way
-# they would type it: with a glob, a `$(...)`, an `&&` chain. `shlex.split` + argv
-# exec turns every one of those into a LITERAL argument --
-# `node --test $(ls test/*.test.js) && swiftc …` becomes
-# ['node','--test','$(ls','test/*.test.js)','&&','swiftc',…] and exits 1 -- which in
-# the receipt is indistinguishable from a genuinely failing suite. So a string that
-# carries shell syntax is run BY a shell; a plain-argv string keeps the faster,
-# quote-exact argv path it has always had.
+# ONE INTERPRETER FOR ONE `resolved_commands[]` LIST.
 #
-# POSIX-sh metacharacters only (no brace expansion, no `~`): every one of these
-# changes what the string MEANS, and `/bin/sh` is what the author was writing for.
-_SHELL_META = frozenset("$`&|;<>()*?[\n")
+# The plugin runs the SAME resolved commands under two different interpreters. Every
+# external worker runs each one through a shell, byte-identically:
+#
+#   compound-v-run-codex-worker.sh:189   -- /bin/bash -c "$_tc_c"
+#   compound-v-run-cursor-worker.sh:203        (and antigravity, opencode)
+#
+# while this, the claude backend's tier-1 floor, ran `shlex.split(raw)` as argv. So a
+# floor with a glob, a `$(...)` or an `&&` chain PASSES on a codex job and FAILS on a
+# claude job of the same manifest -- and `floor_command` is documented only as
+# "string" (execution-manifest.md), with the validator checking only its type. Two
+# backends disagreeing about what a manifest string means is the defect; argv is the
+# odd one out, not a boundary anyone chose.
+#
+# So: the same `/bin/bash -c` the workers already use, for every command. A heuristic
+# that shelled only "suspicious" strings was the first shape of this fix and was
+# worse -- it added a THIRD semantics (argv here, `sh` there, `bash` in the workers),
+# so `pytest tests/{a,b}` would still mean one thing on codex and another here.
+_TEST_SHELL = ("/bin/bash", "-c")
 
 
 def _test_command_argv(raw):
-    """``(argv, spelling, via_shell)`` for one configured test command.
+    """``(argv, spelling)`` for one configured test command.
 
     ``spelling`` stays the ORIGINAL string: `" ".join(shlex.split(x))` is lossy --
     `sh -c "exit 0"` comes back as `sh -c exit 0`, a different command -- and B2
     recomputes the next run's "previously failing" set from these strings.
-
-    An unbalanced quote makes `shlex.split` raise; that returns an EMPTY argv so the
-    caller fails closed with a reason, rather than the whole floor dying on a
-    traceback.
     """
     if not isinstance(raw, str):
+        # A list is already an argv the author spelled out; quote it back into one
+        # string so it means the same thing to the shell.
         cmd = list(raw)
-        return cmd, " ".join(shlex.quote(part) for part in cmd), False
-    if any(ch in _SHELL_META for ch in raw):
-        return ["/bin/sh", "-c", raw], raw, True
-    try:
-        return shlex.split(raw), raw, False
-    except ValueError:
-        return [], raw, False
+        spelling = " ".join(shlex.quote(part) for part in cmd)
+        return list(_TEST_SHELL) + [spelling], spelling
+    return list(_TEST_SHELL) + [raw], raw
 
 
 TEST_OUTPUT_TAIL_BYTES = 2000
 
 
 def _redact_output(text):
-    """Redact secret-shaped strings using the CANONICAL families, or drop the text.
+    """Redact the canonical secret families from captured output, or drop the text.
 
     The floor's captured output is written into `receipts/<id>.gate.json`, which the
-    wave finalizer `git add`s -- so it is durable and committed. Test output routinely
-    carries env dumps and tokenised URLs, and nothing else on this path redacts. The
-    patterns are imported from compound-v-memory.py rather than re-spelled here (the
-    repo forbids a second copy). If that import is unavailable, the text is DROPPED:
-    no diagnostic is worth committing an unredacted credential.
+    wave finalizer `git add`s -- so it is durable and committed, and nothing else on
+    this path redacts.
+
+    HONEST SCOPE. `cv_memory.redact` covers the families that engine names: PEM key
+    blocks, `sk-`, `ghp_`/`gho_`/`github_pat_`, `AKIA`, `xox*`. It does NOT cover
+    `password=`, a credentialed URL (`postgres://u:p@host`), a bare JWT, or
+    `AWS_SECRET_ACCESS_KEY=` -- `compound-v-epic-arbiter.py` carries wider patterns
+    for its egress path and this does not reuse them. So this reduces the exposure a
+    committed tail creates; it does not eliminate it, and a floor that prints its
+    environment can still leak. Widening it means widening the canonical families,
+    not spelling a second set here (CONVENTIONS.md: imported, never redefined).
+
+    If the import is unavailable the text is DROPPED rather than stored raw.
     """
     try:
         engine = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -769,7 +779,11 @@ def _impacted_for(contract, paths):
                     "'run' are mandatory) — a half-declared rule selects nothing" % i)
             if mod.matches(path, when):
                 matched = True
-                commands.append(run.replace("{path}", path))
+                # QUOTED: the path comes from `git diff` of the worker's tree, and
+                # every command now goes through a shell, so an unquoted path
+                # containing a space, `;` or `$(` would change what runs. This is
+                # what `referencing_tests` already does with `shlex.quote(rel)`.
+                commands.append(run.replace("{path}", shlex.quote(path)))
         if not matched:
             unmapped.append(path)
     return commands, unmapped
@@ -1267,20 +1281,18 @@ def run_test_floor(worktree, baseline="HEAD", changed_paths=None, test_cmd=None,
                 result["reasons"].append(
                     "tier-1: configured test command is empty (fail-closed)")
                 return result
-            cmd, spelling, via_shell = _test_command_argv(raw)
-            if not cmd:
+            cmd, spelling = _test_command_argv(raw)
+            if not spelling.strip():
                 result["reasons"].append(
                     "tier-1: configured test command is empty (fail-closed)")
                 return result
-            argvs.append((cmd, spelling, via_shell))
+            argvs.append((cmd, spelling))
         failed_cmds = []
-        for cmd, spelling, via_shell in argvs:
+        for cmd, spelling in argvs:
             rc, out = _run_supervised(cmd, worktree, test_timeout_s,
                                       capture_stderr=True)
             check = {"tier": 1, "checker": spelling, "rc": rc,
                      "status": "pass" if rc == 0 else "fail"}
-            if via_shell:
-                check["via"] = "/bin/sh -c"
             tail = _output_tail(out) if rc != 0 else ""
             if tail:
                 check["output_tail"] = tail
@@ -2114,14 +2126,20 @@ def _selftest():
         # Each of these three is a DISCRIMINATOR: under the old shlex.split+argv
         # path it produced the opposite verdict, which is why a floor with a glob
         # or an `&&` chain read as "my tests are failing".
-        expect("plain argv command stays on the argv path",
-               _test_command_argv("npm test") == (["npm", "test"], "npm test", False))
-        _argv, _spell, _viash = _test_command_argv("node --test $(ls t/*.js) && x")
-        expect("shell syntax routes through sh -c",
-               _viash and _argv[:2] == ["/bin/sh", "-c"]
-               and _argv[2] == "node --test $(ls t/*.js) && x")
+        # ONE interpreter, the same `/bin/bash -c` every external worker already
+        # uses — so a manifest string cannot mean one thing on codex and another
+        # here. No heuristic: a plain command goes through the shell too.
+        expect("a plain command goes through the same shell",
+               _test_command_argv("npm test")
+               == (["/bin/bash", "-c", "npm test"], "npm test"))
+        _argv, _spell = _test_command_argv("node --test $(ls t/*.js) && x")
+        expect("shell syntax is handed to the shell verbatim",
+               _argv == ["/bin/bash", "-c", "node --test $(ls t/*.js) && x"])
         expect("the ORIGINAL string is kept as the spelling",
                _spell == "node --test $(ls t/*.js) && x")
+        expect("a LIST command is quoted back into one shell string",
+               _test_command_argv(["a b", "c"])
+               == (["/bin/bash", "-c", "'a b' c"], "'a b' c"))
         # `&&` must actually chain: argv-exec ran only the first command and passed.
         res = run_test_floor(r, "HEAD", changed_paths=["a.py"],
                              test_cmd="sh -c 'exit 0' && sh -c 'exit 1'")
@@ -2554,13 +2572,16 @@ def _selftest():
         expect("B1: later commands still RUN (no short-circuit ⇒ complete failures)",
                os.path.isfile(marker))
         # Recorded VERBATIM, not shlex-joined. B2 rebuilds the next run's
-        # "previously failing" set from these strings, so the test asserts the
-        # property that matters — the recorded spelling re-parses to the argv
-        # that actually ran — rather than a particular rendering of it.
+        # "previously failing" set from these strings, so the property that matters
+        # is that the recorded spelling is RE-RUNNABLE THROUGH THE SAME ROUTER --
+        # `_test_command_argv` hands it to the shell unchanged. (It is no longer
+        # "re-parses to the argv that ran": nothing is shlex-split on the way to
+        # execution any more, which is the point of running one interpreter.)
         expect("B1: the failing command is recorded by name",
                res.get("failures") == ["sh -c 'exit 1'"])
-        expect("B1: the recorded failure is re-runnable, not lossily joined",
-               shlex.split(res.get("failures", [""])[0]) == ["sh", "-c", "exit 1"])
+        expect("B1: the recorded failure re-runs through the same router",
+               _test_command_argv(res.get("failures", [""])[0])[0]
+               == ["/bin/bash", "-c", "sh -c 'exit 1'"])
         res = run_test_floor(r, base, changed_paths=["a.py"],
                              test_commands=["sh -c 'exit 0'", "sh -c 'exit 0'"])
         expect("B1: an all-green resolved set passes the floor",


### PR DESCRIPTION
Closes defect 1 of #12 and defect 3a of #15. (#16 folded in here - it keys on the same floor document and should be bisected with this.)

Two halves of one story: what a `test_contract` command means to its **executor**, and what the floor document means to its **consumer**.

---

## 1. One interpreter for one command list

The plugin runs the same `resolved_commands[]` under two different interpreters. Every external worker runs each command through a shell, byte-identically:

```
compound-v-run-codex-worker.sh:189   -- /bin/bash -c "$_tc_c"
cursor:203 · antigravity:196 · opencode:237
```

while the claude backend's tier-1 floor ran `shlex.split(raw)` as argv (`compound-v-fastpath-run.py:1167,1177`).

So a floor with a glob, `$(...)` or an `&&` chain **passes on a codex job and fails on a claude job of the same manifest**. `floor_command` is documented only as `string` (`execution-manifest.md:591`) and the validator checks only its type (`validate-manifest.py:2174`), so neither spelling is wrong - the two backends simply disagree about what a manifest string means. argv is the odd one out, and nothing chose it: `shlex.split` arrived unremarked in `65114b08` and was carried forward in `2d178edd`; no commit, doc or ADR mentions argv, shell or injection.

**Every command now goes through the same `/bin/bash -c` the workers use.**

An earlier revision shelled only strings containing metacharacters. That was worse: it added a **third** semantics, so `pytest tests/{a,b}` still meant one thing on codex and another here. The heuristic is gone.

`{path}` substitution is now `shlex.quote`d (`:774`), matching what `referencing_tests` already does at `:741`. Paths come from `git diff` of the worker's tree and are no longer inert once every command reaches a shell.

## 2. The receipt keeps the evidence

`_run_supervised` returns `(rc, stdout_bytes)`; the caller wrote `rc, _ = …` and discarded it, so a failing floor recorded a bare exit code while holding the output that explains it.

The bounded tail now lands on `checks[].output_tail`, **with stderr captured** - a broken command (sh syntax error, module-not-found, `ls: cannot access`) prints there and nowhere else, which is exactly the "broken command vs broken test" ambiguity this exists for.

It is redacted through the canonical families imported from `compound-v-memory.py` (CONVENTIONS.md: imported, never redefined), and the docstring states the **honest scope**: PEM / `sk-` / `ghp_` / `AKIA` / `xox*` are covered; `password=`, credentialed URLs and bare JWTs are **not**. This reduces what a committed receipt can leak; it does not eliminate it.

The tail never enters `reasons[]`: the emitter copies a reason matching `"timeout after"` into `tests.failures[]`, `previously_failing()` reads that back and `resolve_test_commands` re-runs it - command output there would be a path from a test's stdout to the next run's shell.

## 3. The consumer half (emitter)

`run_test_floor` initialises every result `{"passed": false, "merge_blocked": true}` and ADR 0003 relies on it: *"already merge-blocking and already fail-closed on an empty command"*, Consequences: *"A job reporting no test command at all is a FAIL, not a pass."* `agents/spec-reviewer.md` enforces the same in prose (`NO_TEST_EVIDENCE` - "Silence is not success").

`build_review_spec` gate 1 honours that field. `_job_result_from` did not: it reads the floor only through `_tests_block_from_floor`, which returns `None` when no check carries a `checker`, so `merge_blocked: true` was never consulted and the job kept the scope verdict's `success`. **Same document, two consumers, opposite conclusions.** Dogfood 14 moved the *red* half of that rule into this function; this is the empty half.

- The predicate is the **manifest's declaration**, not the resolved slice - the slice is absent exactly when resolution *failed*, the reachable case.
- `tests is None` is `error` (broken machinery), not `blocked`.
- The refusal carries the floor's own reasons into `summary` instead of falling back to the job title.
- Unchanged: an uncontracted manifest still records `success` with no `tests` object.

**Frequency of this fail-open, stated honestly: never observed.** 0 of 198 recorded results here and 0 of 17 in the reporting project. It is a latent fail-open found by reading, not a reproduced defect - an earlier revision claimed otherwise from a narrative I had not checked against the run record, and that claim is withdrawn.

## Regressions considered

- **No docs-only false positive.** `resolve_test_commands` puts `floor_command` first at every tier and raises on an empty set, so a docs-only change still resolves to `[floor_command]` and produces a `checks[]` entry; `tests_block` is non-None and the empty-floor rule cannot fire.
- `capture_stderr` defaults False, so `_git` and every other caller are untouched.
- `job_result.tests` (schema `additionalProperties: false`) is unaffected: `_tests_block_from_floor` reads only `checker`/`rc`. `output_tail` lands only in `receipts/<id>.gate.json`, which V-memory does not index.
- The selftest invariant "the recorded spelling re-parses to the argv that ran" is updated: nothing is shlex-split on the way to execution any more, so the property is now "re-runnable through the same router".

## Tests

`fastpath --selftest` PASSED; emitter **534/534** (was 526/526). Mutation-checked on both halves. Full `scripts/*.py --selftest` sweep, `lint-frontmatter`, `rules-lint` green locally.

## Note on CI

The red `Full test suite` is `tests/test-native-points.sh`, which fails 2 PRECOMPACT rows on a clean `main` too - the hardcoded-date time bomb that #11 fixes. Not from this branch.
