### PR TITLE
fix(emit): a contracted floor that ran nothing is not a pass

### DIFF
--- a/scripts/compound-v-emit-workflow.py
+++ b/scripts/compound-v-emit-workflow.py
@@ -4335,6 +4335,7 @@ def external_session_id(run_dir, job_id):
 
 
 def _job_result_from(verdict, job, state_job, tests=None, contract=None,
+                     contract_declared=False,
                      isolation=None, tier=None):
     """The canonical job_result. Enforcement fields come from the GATE, not the
     implementer: `blocked`, `files_changed` and `violations` are git-derived.
@@ -4387,6 +4388,7 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
     # `blocked`, not `error`: nothing is broken about the machinery, the job's work
     # did not pass its own declared tests. Same class as an out-of-lane write, for
     # the same reason — the work is refused, not the pipeline.
+    result_summary_suffix = ""
     tests_block = _tests_block_from_floor(tests, contract, job, tier) if tests else None
     if status == "success" and isinstance(tests_block, dict):
         t_exit = tests_block.get("exit_code")
@@ -4399,27 +4401,47 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
             # consumer of the boolean got the opposite conclusion.
             pass
 
-    # A CONTRACTED FLOOR THAT RAN NOTHING IS NOT A PASS.
+    # A CONTRACTED FLOOR THAT RESOLVED TO NO COMMAND IS NOT A PASS.
     #
-    # The rule above closed the RED floor. This closes the EMPTY one, which the
-    # same run showed is the more dangerous half: `_tests_block_from_floor` returns
-    # None when the floor executed no command ("absent is honest" — the schema says
-    # omit the object rather than report a fabricated zero), and `isinstance(...,
-    # dict)` above is then False, so the job keeps `success` with NO test evidence
-    # at all.
+    # `run_test_floor` initialises every result `{"passed": False, "merge_blocked":
+    # True}` — refusal is the floor's default state — and ADR 0003 relies on it:
+    # "already merge-blocking and already fail-closed on an empty command", with
+    # Consequences: "A job reporting no test command at all is a FAIL, not a pass."
+    # `spec-reviewer.md` enforces that in prose (ISSUE: NO_TEST_EVIDENCE, "Silence
+    # is not success").
     #
-    # Dogfooded: two sibling worktree jobs, same wave. One installed the project's
-    # dependencies so its floor could run, and was BLOCKED for the install. The
-    # other installed nothing, so its floor could not run at all — and PASSED. A job
-    # that made its floor runnable was refused; a job whose floor never ran was
-    # merged. Absent evidence was being read as absence of objection.
+    # The fast path's own consumer honours it (`build_review_spec` gate 1 refuses on
+    # `not passed or merge_blocked`). THIS consumer did not: it reads the floor only
+    # through `_tests_block_from_floor`, which returns None when no check carries a
+    # `checker`, so `merge_blocked: True` was never consulted and the job kept the
+    # scope verdict's `success`. One floor document, two consumers, opposite
+    # conclusions. Dogfood 14 moved the RED half of the rule from prose into this
+    # function; this is the empty half, at the same layer, for the same reason.
     #
-    # Narrow on purpose: this fires ONLY when the manifest actually contracted a
-    # floor. A job with no `test_contract` has nothing to run and stays `success`
-    # (the "no floor at all is not a failure" rule is unchanged). `blocked`, not
-    # `error`: the machinery is fine, the job simply has no evidence it may merge on.
-    if status == "success" and tests_block is None and contract:
-        status = "blocked"
+    # The predicate is the MANIFEST's declaration, not the resolved slice. `contract`
+    # above is read from `jobs/<id>.test-contract.json`, which does not exist when
+    # resolution FAILED — precisely the case that must be caught. Keying on it would
+    # leave the reachable hole open.
+    #
+    # Unchanged: an uncontracted manifest still records `success` with no `tests`
+    # object — "no floor at all is not a failure".
+    if status == "success" and tests_block is None and contract_declared:
+        if tests is None:
+            # No floor document at all: `fastpath-run.py` was absent or died before
+            # writing JSON. The machinery IS broken here, so `error`, not `blocked`.
+            status = "error"
+        else:
+            status = "blocked"
+        _floor_reasons = [str(r) for r in ((tests or {}).get("reasons") or []) if r]
+        if _floor_reasons:
+            # Without this the refusal carries no cause: the floor's own
+            # "test contract did not resolve (fail-closed): ..." is dropped and the
+            # summary falls back to the job title, which is a refusal for an
+            # unstated reason.
+            result_summary_suffix = "; ".join(_floor_reasons[:3])
+        else:
+            result_summary_suffix = ("the manifest declares a test_contract but the "
+                                     "floor resolved to no command")
 
     # The three REQUIRED fields below are typed `string`/`string`/`integer` in the
     # schema, with the empty string and 0 documented as their own "not applicable"
@@ -4458,7 +4480,8 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
         "violations": violations,
         "summary": (("implementer returned no result (turn cap or crash); the registered "
                      "worktree was gated as evidence — " if _impl_no_result else "")
-                    + (verdict.get("reason") or (job.get("title") or job.get("id") or ""))),
+                    + (verdict.get("reason") or (job.get("title") or job.get("id") or ""))
+                    + (" - " + result_summary_suffix if result_summary_suffix else "")),
         "session_id": state_job.get("session_id") or "",  # filled from the events log for an external job (finding 81)
         "worktree": worktree,
         "exit_code": exit_code,
@@ -4734,8 +4757,14 @@ def cmd_record(argv):
 
             state_job["session_id"] = _ext_sid
 
+    # Whether the MANIFEST declared a floor — not whether the slice resolved. The
+    # slice is absent exactly when resolution failed, which is the case that must
+    # not pass silently. Mirrors `declares_contract` in build_plan.
+    _contract_declared = isinstance(manifest.get("test_contract"), dict) and bool(
+        manifest.get("test_contract"))
     result = _job_result_from(verdict, job, state_job, tests=tests,
-                              contract=contract, isolation=isolation, tier=tier)
+                              contract=contract, isolation=isolation, tier=tier,
+                              contract_declared=_contract_declared)
 
     # ---- the workflow's retry log ------------------------------------------
     # It lands in state.json and in this ack, NOT as a new top-level key on the
@@ -6241,27 +6270,45 @@ def selftest():
         _check("no floor at all is not a failure",
                _jr_none["status"] == "success")
 
-        # A CONTRACTED floor that ran nothing must NOT pass: `_tests_block_from_floor`
-        # returns None for an empty `checks` list, so before this rule the job kept
-        # `success` with no test evidence at all. Dogfooded: the sibling job that
-        # installed dependencies so its floor could run was BLOCKED for the install,
-        # while this one — whose floor never ran — merged.
+        # A CONTRACTED floor that resolved to NO COMMAND must not pass.
+        # `_tests_block_from_floor` returns None for an empty `checks` list, so the
+        # red-floor rule above cannot see it and the job kept the scope verdict's
+        # `success` — while the floor document itself said `merge_blocked: True`.
+        _empty_floor = {"phase": "test_floor", "tier_used": 0, "passed": False,
+                        "merge_blocked": True, "checks": [],
+                        "reasons": ["test contract did not resolve (fail-closed)"]}
         _jr_empty = _job_result_from(
             _clean_verdict,
             {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
-            tests={"phase": "test_floor", "tier_used": 0, "passed": False,
-                   "merge_blocked": True, "checks": [], "reasons": ["nothing ran"]},
-            contract={"floor_command": "npm test"})
-        _check("a CONTRACTED floor that ran nothing is blocked, not success",
+            tests=_empty_floor, contract_declared=True)
+        _check("a CONTRACTED floor that resolved to no command is blocked",
                _jr_empty["status"] == "blocked", str(_jr_empty["status"]))
         _check("...and it carries no fabricated tests block",
-               _jr_empty.get("tests") in (None, {}) or "tests" not in _jr_empty)
+               "tests" not in _jr_empty or _jr_empty.get("tests") in (None, {}))
+        _check("...and the refusal states the floor's OWN reason",
+               "did not resolve" in (_jr_empty.get("summary") or ""),
+               str(_jr_empty.get("summary")))
+        # The predicate is the MANIFEST's declaration, not the resolved slice: the
+        # slice is missing exactly when resolution failed, so keying on it would
+        # leave the reachable hole open.
+        _jr_slice = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=_empty_floor, contract={}, contract_declared=True)
+        _check("a declared contract whose SLICE is missing is still caught",
+               _jr_slice["status"] == "blocked", str(_jr_slice["status"]))
+        # No floor document at all is broken machinery, not a refused job.
+        _jr_nodoc = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests=None, contract_declared=True)
+        _check("a contracted job whose floor produced NO document is error",
+               _jr_nodoc["status"] == "error", str(_jr_nodoc["status"]))
         # The narrowness is the point: no contract, no obligation.
         _jr_nocontract = _job_result_from(
             _clean_verdict,
             {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
-            tests={"phase": "test_floor", "tier_used": 0, "passed": False,
-                   "merge_blocked": True, "checks": [], "reasons": ["nothing ran"]})
+            tests=_empty_floor)
         _check("an UNcontracted job with no floor evidence still passes",
                _jr_nocontract["status"] == "success", str(_jr_nocontract["status"]))
 

--- a/scripts/compound-v-emit-workflow.py
+++ b/scripts/compound-v-emit-workflow.py
@@ -4399,6 +4399,28 @@ def _job_result_from(verdict, job, state_job, tests=None, contract=None,
             # consumer of the boolean got the opposite conclusion.
             pass
 
+    # A CONTRACTED FLOOR THAT RAN NOTHING IS NOT A PASS.
+    #
+    # The rule above closed the RED floor. This closes the EMPTY one, which the
+    # same run showed is the more dangerous half: `_tests_block_from_floor` returns
+    # None when the floor executed no command ("absent is honest" — the schema says
+    # omit the object rather than report a fabricated zero), and `isinstance(...,
+    # dict)` above is then False, so the job keeps `success` with NO test evidence
+    # at all.
+    #
+    # Dogfooded: two sibling worktree jobs, same wave. One installed the project's
+    # dependencies so its floor could run, and was BLOCKED for the install. The
+    # other installed nothing, so its floor could not run at all — and PASSED. A job
+    # that made its floor runnable was refused; a job whose floor never ran was
+    # merged. Absent evidence was being read as absence of objection.
+    #
+    # Narrow on purpose: this fires ONLY when the manifest actually contracted a
+    # floor. A job with no `test_contract` has nothing to run and stays `success`
+    # (the "no floor at all is not a failure" rule is unchanged). `blocked`, not
+    # `error`: the machinery is fine, the job simply has no evidence it may merge on.
+    if status == "success" and tests_block is None and contract:
+        status = "blocked"
+
     # The three REQUIRED fields below are typed `string`/`string`/`integer` in the
     # schema, with the empty string and 0 documented as their own "not applicable"
     # values ("Empty string when the backend has no resumable session"; "empty
@@ -6218,6 +6240,30 @@ def selftest():
                                      "write_allowed": ["docs/x/**"]}, {})
         _check("no floor at all is not a failure",
                _jr_none["status"] == "success")
+
+        # A CONTRACTED floor that ran nothing must NOT pass: `_tests_block_from_floor`
+        # returns None for an empty `checks` list, so before this rule the job kept
+        # `success` with no test evidence at all. Dogfooded: the sibling job that
+        # installed dependencies so its floor could run was BLOCKED for the install,
+        # while this one — whose floor never ran — merged.
+        _jr_empty = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests={"phase": "test_floor", "tier_used": 0, "passed": False,
+                   "merge_blocked": True, "checks": [], "reasons": ["nothing ran"]},
+            contract={"floor_command": "npm test"})
+        _check("a CONTRACTED floor that ran nothing is blocked, not success",
+               _jr_empty["status"] == "blocked", str(_jr_empty["status"]))
+        _check("...and it carries no fabricated tests block",
+               _jr_empty.get("tests") in (None, {}) or "tests" not in _jr_empty)
+        # The narrowness is the point: no contract, no obligation.
+        _jr_nocontract = _job_result_from(
+            _clean_verdict,
+            {"id": "j", "backend": "claude", "write_allowed": ["docs/x/**"]}, {},
+            tests={"phase": "test_floor", "tier_used": 0, "passed": False,
+                   "merge_blocked": True, "checks": [], "reasons": ["nothing ran"]})
+        _check("an UNcontracted job with no floor evidence still passes",
+               _jr_nocontract["status"] == "success", str(_jr_nocontract["status"]))
 
         _check("a lane-declaring job with no observable worktree is RECORDED",
                rc_nw == 0 and isinstance(nw_res, dict), str(rc_nw))


### PR DESCRIPTION
Fixes defect 3a of #15.

## The defect, from the invariants

**`record` discards the floor's own fail-closed verdict when the floor resolved to no command.**

`run_test_floor` initialises every result as `{"passed": false, "merge_blocked": true}` and documents "`merge_blocked` is True on any floor FAILURE (Iron-Invariant #6)". `_cmd_test_floor` emits exactly that document on `TestContractError`. ADR 0003 relies on it: "`run_test_floor` is already merge-blocking and already fail-closed on an empty command."

The fast path's own consumer honours it - `build_review_spec` gate 1 refuses on `not passed or merge_blocked`. Engine C's consumer does not: `_job_result_from` reads the floor only through `_tests_block_from_floor`, which returns `None` when `checks[]` carries no `checker`, so `merge_blocked: true` is never consulted and the job keeps the scope verdict's `success`. **Same floor document, two consumers, opposite conclusions.**

ADR 0003 Consequences: "A job reporting no test command at all is a FAIL, not a pass." `agents/spec-reviewer.md` enforces that in prose (`ISSUE: NO_TEST_EVIDENCE` - "Silence is not success; an absent record is exactly what a worker that skipped the step looks like"). Dogfood 14 moved the **red** half of the rule from prose into `record`, because "the `tests` block is the fourteenth mechanism this project built and left without a consumer". This closes the **empty** half at the same layer, for the same reason.

## Frequency, stated honestly

**Never observed.** 0 of 198 recorded results in this repository and 0 of 17 in the reporting project show `success` with no `tests` block under a contracted manifest. The run in #15 was caught by the red-floor rule: `task-4-wire` was `status: blocked`, `tests.exit_code: 1` - its floor did run and went red.

This is a latent fail-open found by reading the code, not a reproduced defect. An earlier revision of this PR claimed otherwise on the strength of a narrative I had not checked against the run record; that claim is withdrawn.

## The rule

```python
if status == "success" and tests_block is None and contract_declared:
    status = "error" if tests is None else "blocked"
```

- **The predicate is the manifest's declaration**, not the resolved slice. `contract` is read from `jobs/<id>.test-contract.json`, which does not exist precisely when resolution *failed* - the reachable case (a manifest declaring `impacted_map` with no `full_command` passes the validator, then the resolver raises and no slice is written). Keying on the slice would leave that hole open.
- **`tests is None` is `error`, not `blocked`.** No floor document at all means `fastpath-run.py` was absent or died before writing JSON - the machinery is broken, which is a different taxonomy from a refused job.
- **The refusal carries the floor's own reasons** into `summary`. It previously fell back to the job title, which is a refusal for an unstated reason - the failure mode the gate-receipt code itself warns about.

## Not changed

An uncontracted manifest still records `success` with no `tests` object - "no floor at all is not a failure" (dogfood 14), and the emitter's own note that "the worker runs no tests and reports no `tests` object, which is the documented honest outcome, not a silent zero".

**No false positives for docs-only jobs.** `resolve_test_commands` puts `floor_command` first at every tier and raises on an empty set, so a docs-only change at SCOPED/DIRECT/FULL still resolves to `[floor_command]` and produces a `checks[]` entry. A job whose floor legitimately has nothing impacted to run still has a floor, so `tests_block` is non-None and this rule cannot fire.

## Tests

532/532 (was 526/526 on `main`). Six rows: a contracted floor that resolved to no command is blocked; it carries no fabricated tests block; the refusal states the floor's own reason; a declared contract whose *slice* is missing is still caught; no floor document at all is `error`; an uncontracted job still passes.

Mutation-checked - disabling the rule fails four of the six.

Full `scripts/*.py --selftest` sweep, `lint-frontmatter`, `rules-lint` green locally.

## Note on CI

The red `Full test suite` is `tests/test-native-points.sh`, which fails 2 PRECOMPACT rows on a clean `main` too - the hardcoded-date time bomb that #11 fixes. Not from this branch.
